### PR TITLE
Add support for CPP inference with decoder

### DIFF
--- a/examples/canary/run.py
+++ b/examples/canary/run.py
@@ -463,6 +463,7 @@ class CanaryEncoder:
         enc_mask, emb_len = self.get_masked_emb(enc_outputs)
         if self.enc_dec_proj is not None:
             enc_mask = self.enc_dec_proj(enc_mask.to(dtype=torch.float32))
+        emb_len = torch.clip(emb_len, max=enc_mask.shape[1])
         return enc_mask, emb_len
 
 


### PR DESCRIPTION
Decoder can now be run via `ModelRunnerCpp` by removing `--use_py_session` from the run command.