### PR TITLE
Changes to convert decoder for different trtllm versions.

### DIFF
--- a/examples/canary/requirements.txt
+++ b/examples/canary/requirements.txt
@@ -3,9 +3,9 @@ torch>=2.5.0
 pytorch-lightning>=2.4.0
 safetensors
 kaldialign
-tensorrt_llm==0.19.0rc0
+tensorrt_llm>=0.17.0
 datasets
 lhotse
-nemo_toolkit[asr]==2.3.0rc4
+nemo_toolkit[asr]==2.3.0
 librosa
 protobuf>=4.25.4

--- a/examples/canary/requirements.txt
+++ b/examples/canary/requirements.txt
@@ -3,8 +3,9 @@ torch>=2.5.0
 pytorch-lightning>=2.4.0
 safetensors
 kaldialign
-tensorrt_llm>=0.17.0
+tensorrt_llm==0.19.0rc0
 datasets
 lhotse
-nemo_toolkit[asr]==2.2.0
+nemo_toolkit[asr]==2.3.0rc4
 librosa
+protobuf>=4.25.4


### PR DESCRIPTION
TensorRT-LLM v0.19.0 onwards require a change in decoder weight names. This PR makes sure that the conversion works properly for both v0.17.0 and v0.19.0