### PR TITLE
Magpie/1.1.0rc6

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
@@ -47,7 +47,7 @@ public:
     runtime::SizeType32 operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
         runtime::ITensor::SharedPtr const& logits, std::vector<runtime::SizeType32> const& numContextLogitsVec,
         runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
-        OptionalRef<MedusaBuffers> medusaBuffers) const;
+        OptionalRef<MedusaBuffers> medusaBuffers, tr::SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
@@ -45,9 +45,10 @@ public:
     HandleGenerationLogits() = default;
 
     void operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
-        runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
+        runtime::CudaStream const& stream, runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
         runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
-        OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers) const;
+        OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers,
+        runtime::SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -888,7 +888,7 @@ public:
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnPartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt);
+        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, SizeType32 numVocabs = 1);
 
     BlockManager(BlockManager const&) = delete;
     BlockManager& operator=(BlockManager const&) = delete;
@@ -1416,7 +1416,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1427,7 +1428,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1438,7 +1440,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1446,7 +1449,7 @@ public:
         std::optional<TempAttentionWindowInputs> const& tempAttentionWindowInputs, nvinfer1::DataType dtype,
         SizeType32 sinkTokenLength, int64_t stream, std::optional<SizeType32> maxSequenceLength,
         bool enableBlockReuse = false, bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
-        bool enablePartialReuse = true, bool copyOnpartialReuse = true);
+        bool enablePartialReuse = true, bool copyOnpartialReuse = true, SizeType32 numVocabs = 1);
 
     ~KVCacheManager() override = default;
 

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -76,7 +76,8 @@ public:
         std::optional<SizeType32> const& noRepeatNgramSize = std::nullopt,
         std::optional<SizeType32> const& numReturnSequences = std::nullopt,
         std::optional<FloatType> const& minP = std::nullopt,
-        std::optional<std::vector<SizeType32>> const& beamWidthArray = std::nullopt);
+        std::optional<std::vector<SizeType32>> const& beamWidthArray = std::nullopt,
+        std::optional<FloatType> const& cfgScale = std::nullopt);
 
     bool operator==(SamplingConfig const& other) const;
 
@@ -100,6 +101,7 @@ public:
     [[nodiscard]] std::optional<SizeType32> getNumReturnSequences() const;
     [[nodiscard]] std::optional<FloatType> getMinP() const;
     [[nodiscard]] std::optional<std::vector<SizeType32>> getBeamWidthArray() const;
+    [[nodiscard]] std::optional<FloatType> getCfgScale() const;
 
     void setBeamWidth(SizeType32 beamWidth);
     void setTopK(std::optional<SizeType32> const& topK);
@@ -120,6 +122,7 @@ public:
     void setNumReturnSequences(std::optional<SizeType32> const& numReturnSequences);
     void setMinP(std::optional<FloatType> const& minP);
     void setBeamWidthArray(std::optional<std::vector<SizeType32>> const& beamWidthArray);
+    void setCfgScale(std::optional<FloatType> const& cfgScale);
 
 private:
     static SizeType32 checkBeamWidth(SizeType32 beamWidth);
@@ -141,6 +144,7 @@ private:
     static std::optional<FloatType> const& checkMinP(std::optional<FloatType> const& minP);
     static std::pair<std::optional<std::vector<SizeType32>> const&, SizeType32 const> const checkBeamWidthArray(
         std::optional<std::vector<SizeType32>> const& beamWidthArray, SizeType32 const beamWidth);
+    static std::optional<FloatType> const& checkCfgScale(std::optional<FloatType> const& cfgScale);
     void updateNumReturnBeams();
 
     friend class Serialization;
@@ -192,6 +196,8 @@ private:
     std::optional<FloatType> mMinP;
     /// @brief Controls the beam width for each step for Variable-Beam-Width-Search.
     std::optional<std::vector<SizeType32>> mBeamWidthArray;
+    /// @brief Controls the cfg scale for sampling.
+    std::optional<FloatType> mCfgScale;
 };
 
 /// @brief Additional output that should be gathered.
@@ -660,6 +666,7 @@ public:
     /// @param encoderInputFeatures Encoder input features for multimodal models.
     /// @param encoderOutputLength Encoder output length if encoder input and output have different lengths (due to
     /// convolution down-sampling, etc.)
+    /// @param decoderContextFeatures Decoder context features for multimodal models.
     /// @param crossAttentionMask Cross attention mask.
     /// @param numReturnSequences The number of returning sequences.
     /// @param eagleConfig The EAGLE speculative decoding configuration
@@ -670,6 +677,7 @@ public:
     /// finish reason. The request may exceed this time slightly, but at most by 1 forward pass (in pipeline parallelism
     /// that may involve multiple micro-batches). A request can be timed-out before ever being scheduled.
     /// @param cacheSaltID Salt ID for KV cache blocks to limit the kv cache reuse to the requests with the same string.
+    /// @param numVocabs The number of vocabs.
     Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming = false,
         SamplingConfig const& samplingConfig = SamplingConfig(), OutputConfig const& outputConfig = OutputConfig(),
         std::optional<SizeType32> const& endId = std::nullopt, std::optional<SizeType32> const& padId = std::nullopt,
@@ -692,12 +700,13 @@ public:
         std::optional<ContextPhaseParams> contextPhaseParams = std::nullopt,
         std::optional<Tensor> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<Tensor> decoderContextFeatures = std::nullopt,
         std::optional<Tensor> crossAttentionMask = std::nullopt, SizeType32 numReturnSequences = 1,
         std::optional<EagleConfig> eagleConfig = std::nullopt, std::optional<Tensor> skipCrossAttnBlocks = std::nullopt,
         std::optional<GuidedDecodingParams> guidedDecodingParams = std::nullopt,
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt);
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, SizeType32 numVocabs = 1);
 
     /// @brief This logits postprocessor name will dispatch to the batched logits postprocessor
     static auto constexpr kBatchedPostProcessorName = "batched";
@@ -738,6 +747,7 @@ public:
     [[nodiscard]] std::optional<ContextPhaseParams> const& getContextPhaseParams() const;
     [[nodiscard]] std::optional<Tensor> getEncoderInputFeatures() const;
     [[nodiscard]] std::optional<SizeType32> getEncoderOutputLength() const;
+    [[nodiscard]] std::optional<Tensor> getDecoderContextFeatures() const;
     [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const;
     [[nodiscard]] RequestType getRequestType() const;
     [[nodiscard]] std::optional<EagleConfig> getEagleConfig() const;
@@ -747,6 +757,7 @@ public:
     [[nodiscard]] std::optional<MillisecondsType> getAllottedTimeMs() const;
     [[nodiscard]] std::optional<CacheSaltIDType> getCacheSaltID() const;
     [[nodiscard]] std::optional<std::vector<std::string>> getAdditionalOutputNames() const;
+    [[nodiscard]] SizeType32 getNumVocabs() const;
 
     void setStreaming(bool streaming);
     void setSamplingConfig(SamplingConfig const& config);
@@ -775,6 +786,7 @@ public:
     void setContextPhaseParams(ContextPhaseParams contextPhaseParams);
     void setEncoderInputFeatures(Tensor encoderInputFeatures);
     void setEncoderOutputLength(SizeType32 encoderOutputLength);
+    void setDecoderContextFeatures(Tensor decoderContextFeatures);
     void setCrossAttentionMask(Tensor crossAttentionMask);
     void setEagleConfig(std::optional<EagleConfig> const& eagleConfig);
     void setSkipCrossAttnBlocks(Tensor skipCrossAttnBlocks);
@@ -782,6 +794,7 @@ public:
     void setLanguageAdapterUid(SizeType32 languageAdapterUid);
     void setAllottedTimeMs(MillisecondsType allottedTimeMs);
     void setCacheSaltID(CacheSaltIDType cacheSaltID);
+    void setNumVocabs(SizeType32 numVocabs);
 
 private:
     friend class Serialization;

--- a/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
+++ b/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
@@ -133,6 +133,11 @@ public:
     {
         return std::vector<runtime::SizeType32>{1};
     }
+
+    [[nodiscard]] __host__ __device__ static constexpr float getCfgScale()
+    {
+        return 1.0f;
+    }
 };
 } // namespace layers
 } // namespace tensorrt_llm

--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -48,7 +48,8 @@ public:
     explicit GptDecoderBatched(CudaStreamPtr stream);
 
     void setup(executor::DecodingMode const& mode, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
-        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig) override;
+        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
+        SizeType32 vocab_size = 0) override;
 
     void disableLookahead(RequestVector const& genRequests, TensorPtr const& batchSlots) override;
 

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -87,7 +87,8 @@ public:
 
     //! @brief Setup the decoder before calling `forward()`
     virtual void setup(executor::DecodingMode const& mode, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
-        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig)
+        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
+        SizeType32 vocab_size = 0)
         = 0;
 
     //! @brief Disable Lookahead decoding.

--- a/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
+++ b/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
@@ -50,6 +50,7 @@ public:
 
     std::vector<bool>
         promptTuningEnabled; // [batchSize] vector of bool that indicates which requests in a batch have ptuning enabled
+    SizeType32 numVocabs;
 };
 
 class PromptTuningParams : public GenericPromptTuningParams<ITensor::SharedPtr>

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -141,6 +141,10 @@ public:
         topP = fuseValues<FloatType>(
             configs, [&configs](size_t ci) { return configs[ci].topP; }, layers::DefaultDecodingParams::getTopP());
 
+        cfgScale = fuseValues<FloatType>(
+            configs, [&configs](size_t ci) { return configs[ci].cfgScale; },
+            layers::DefaultDecodingParams::getCfgScale());
+
         // Generate a random seed for each samplingConfig with randomSeed == std::nullopt
         randomSeed = std::vector<uint64_t>(configs.size());
         for (size_t ci = 0; ci < configs.size(); ++ci)
@@ -229,6 +233,7 @@ public:
         SET_FROM_OPTIONAL(noRepeatNgramSize, NoRepeatNgramSize, SizeType32)
         SET_FROM_OPTIONAL(minP, MinP, FloatType)
         SET_FROM_OPTIONAL(beamWidthArray, BeamWidthArray, std::vector<SizeType32>)
+        SET_FROM_OPTIONAL(cfgScale, CfgScale, FloatType)
 #undef SET_FROM_OPTIONAL
     }
 
@@ -278,6 +283,8 @@ public:
         // valid &= validateVec("lengthPenalty", lengthPenalty, 0.f);
         valid &= validateVec("noRepeatNgramSize", noRepeatNgramSize, 0);
         valid &= validateVec("minP", minP, -fltEpsilon, {1.f});
+        // TODO: validation of cfgScale?
+        valid &= validateVec("cfgScale", cfgScale, -10.0f);
         // TODO: check `beamWidthArray`
 
         // Detect greedy sampling and overwrite params.
@@ -371,6 +378,8 @@ public:
 
     std::optional<bool> normalizeLogProbs;
 
+    OptVec<FloatType> cfgScale; // [1] or [batchSize]
+
     bool operator==(SamplingConfig const& other) const
     {
         return beamWidth == other.beamWidth && numReturnSequences == other.numReturnSequences
@@ -383,7 +392,8 @@ public:
             && lengthPenalty == other.lengthPenalty && earlyStopping == other.earlyStopping
             && draftAcceptanceThreshold == other.draftAcceptanceThreshold && topKMedusaHeads == other.topKMedusaHeads
             && normalizeLogProbs == other.normalizeLogProbs && outputLogProbs == other.outputLogProbs
-            && cumLogProbs == other.cumLogProbs && minP == other.minP && beamWidthArray == other.beamWidthArray;
+            && cumLogProbs == other.cumLogProbs && minP == other.minP && beamWidthArray == other.beamWidthArray
+            && cfgScale == other.cfgScale;
     }
 
     SizeType32 getNumReturnBeams() const

--- a/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
+++ b/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
@@ -35,15 +35,27 @@ void tensorrt_llm::batch_manager::AssignReqSeqSlots::operator()(SequenceSlotMana
                 // Skip assigning sequence slot for DISAGG_GENERATION_INIT request
                 continue;
             }
-            auto const isReqNew = (llmReq->isContextInitState() && !llmReq->mSeqSlot)
+            auto const isReqNew = (llmReq->isContextInitState() && llmReq->mSeqSlots.empty())
                 || (llmReq->isDisaggGenerationTransmissionComplete());
             if (isReqNew && llmReq->getReturnPerfMetrics())
             {
                 llmReq->setFirstScheduledTime();
             }
-            auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->mRequestId);
-            TLLM_CHECK_WITH_INFO(reqSeqSlot, "Unable to get batch slot for request ID %lu", llmReq->mRequestId);
-            llmReq->mSeqSlot = reqSeqSlot;
+            for (int i = 0; i < llmReq->getNumSequences(); i++)
+            {
+                auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->getSeqSlotId(i));
+                TLLM_CHECK_WITH_INFO(
+                    reqSeqSlot, "Unable to get batch slot for request ID %lu", lllmReq->getSeqSlotId(i));
+
+                if ((int) llmReq->mSeqSlots.size() >= i + 1)
+                {
+                    llmReq->mSeqSlots[i] = reqSeqSlot.value();
+                }
+                else
+                {
+                    llmReq->mSeqSlots.push_back(reqSeqSlot.value());
+                }
+            }
         }
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -44,7 +44,7 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
 {
     size_t requestBlockNum = llmRequest.getRequestedBlockHashes().size();
     constexpr SizeType32 beam{0};
-    auto blockRange = BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId, beam);
+    auto blockRange = BlockRange::fromAllBlockIds(*cacheManager, llmRequest, beam);
     auto poolNum = cacheManager->getBlockManager().getNumPools();
     if (poolNum > 1 || common::getEnvDisableSelectiveCacheTransfer())
     {

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -407,9 +407,13 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
                 // If we can't allocate a started request, we need to start freeing started requests
                 // from the end of the vector and try again
                 // Here we simulate freeing the kvCache blocks associated with that sequence
-                kvCacheManager.schedulingRemoveSequence((*lastStartedReqIt)->mRequestId);
+                for (int i = 0; i < (*lastStartedReqIt)->getNumSequences(); i++)
+                {
+                    auto const requestId = (*lastStartedReqIt)->getSeqSlotId(i);
+                    kvCacheManager.schedulingRemoveSequence(requestId);
+                    TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu -> pause", requestId);
+                }
                 pausedRequests.emplace_back(*lastStartedReqIt);
-                TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu -> pause", (*lastStartedReqIt)->mRequestId);
                 reqItEnd = std::next(lastStartedReqIt).base();
             }
             else

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ accelerate>=1.7.0
 build
 colored
 # cuda-python>=12,<13  # <For CUDA 12.9>
-cuda-python>=12
+cuda-python>=13
 diffusers>=0.27.0
 lark
 mpi4py
@@ -15,9 +15,9 @@ openai
 polygraphy
 psutil
 # nvidia-ml-py>=12,<13  # <For CUDA 12.9>
-nvidia-ml-py>=12
+nvidia-ml-py>=13
 # Just a wrapper since nvidia-modelopt requires pynvml
-pynvml==12.0.0
+#pynvml==12.0.0
 pulp
 pandas
 h5py==3.12.1
@@ -31,7 +31,7 @@ torch>=2.8.0a0,<=2.8.0
 torchvision
 nvidia-modelopt[torch]~=0.33.0
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-25-08.html#rel-25-08 uses 2.27.7
-nvidia-nccl-cu12
+nvidia-nccl-cu13
 # nvidia-cuda-nvrtc-cu12  # <For CUDA 12.9>
 nvidia-cuda-nvrtc
 transformers==4.56.0


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
