### PR TITLE
Magpie/1.1.0

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
@@ -47,7 +47,7 @@ public:
     runtime::SizeType32 operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
         runtime::ITensor::SharedPtr const& logits, std::vector<runtime::SizeType32> const& numContextLogitsVec,
         runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
-        OptionalRef<MedusaBuffers> medusaBuffers) const;
+        OptionalRef<MedusaBuffers> medusaBuffers, runtime::SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
@@ -45,9 +45,10 @@ public:
     HandleGenerationLogits() = default;
 
     void operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
-        runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
+        runtime::CudaStream const& stream, runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
         runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
-        OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers) const;
+        OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers,
+        runtime::SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
@@ -45,7 +45,7 @@ public:
     HandleGenerationLogits() = default;
 
     void operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
-        runtime::CudaStream const& stream, runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
+        runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
         runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
         OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers,
         runtime::SizeType32 vocabId = 0) const;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -909,7 +909,7 @@ public:
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnPartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt);
+        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, SizeType32 numVocabs = 1);
 
     BlockManager(BlockManager const&) = delete;
     BlockManager& operator=(BlockManager const&) = delete;
@@ -1434,7 +1434,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1445,7 +1446,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1456,7 +1458,8 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
+        SizeType32 numVocabs = 1);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1464,7 +1467,7 @@ public:
         std::optional<TempAttentionWindowInputs> const& tempAttentionWindowInputs, nvinfer1::DataType dtype,
         SizeType32 sinkTokenLength, int64_t stream, SizeType32 maxSequenceLength, bool enableBlockReuse = false,
         bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF, bool enablePartialReuse = true,
-        bool copyOnpartialReuse = true);
+        bool copyOnpartialReuse = true, SizeType32 numVocabs = 1);
 
     ~KVCacheManager() override = default;
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -553,8 +553,8 @@ public:
         SizeType32 blocksInSecondaryPool, SizeType32 maxNumSequences, std::shared_ptr<runtime::CudaStream> stream,
         bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
         std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
-        std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr, SizeType32 numVocabs = 1);
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, SizeType32 numVocabs = 1,
+        std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr);
 
     ~WindowBlockManager();
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -554,7 +554,7 @@ public:
         bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
         std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
-        std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr);
+        std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr, SizeType32 numVocabs = 1);
 
     ~WindowBlockManager();
 
@@ -888,6 +888,9 @@ private:
     bool mEnablePartialReuse;
     // Whether partially matched blocks that are already in use should be copied and reused.
     bool mCopyOnPartialReuse;
+
+    SizeType32 mNumVocabs;
+
     // The kv cache connector manager
     std::shared_ptr<kv_connector::KvCacheConnectorManager> mKvCacheConnectorManager;
 };
@@ -907,9 +910,9 @@ public:
         SizeType32 sinkBubbleLength, bool onboardBlocks, CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
-        bool copyOnPartialReuse = true,
+        bool copyOnPartialReuse = true, SizeType32 numVocabs = 1,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, SizeType32 numVocabs = 1);
+        std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt);
 
     BlockManager(BlockManager const&) = delete;
     BlockManager& operator=(BlockManager const&) = delete;
@@ -1212,6 +1215,7 @@ private:
     std::vector<SizeType32> mLayerToWindowSize;
     std::vector<SizeType32> mAbsolutePoolToWindowSize;
     std::vector<SizeType32> mAbsolutePoolToRelativePoolIndex;
+    SizeType32 mNumVocabs;
 };
 
 struct OffsetTableDimensions
@@ -1433,9 +1437,8 @@ public:
         bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
-        bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        SizeType32 numVocabs = 1);
+        bool copyOnpartialReuse = true, SizeType32 numVocabs = 1,
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1445,9 +1448,8 @@ public:
         bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
-        bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        SizeType32 numVocabs = 1);
+        bool copyOnpartialReuse = true, SizeType32 numVocabs = 1,
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1457,9 +1459,8 @@ public:
         bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
-        bool copyOnpartialReuse = true,
-        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
-        SizeType32 numVocabs = 1);
+        bool copyOnpartialReuse = true, SizeType32 numVocabs = 1,
+        std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -59,14 +59,6 @@ public:
         return BlockRange(cacheManager, blockIds, requestId);
     }
 
-    static BlockRange fromNewlyAllocatedBlockIds(
-        BaseKVCacheManager const& cacheManager, LlmRequest::RequestIdType requestId)
-    {
-        auto const windowSize = firstWindowSize(cacheManager);
-        auto const blockIds = cacheManager.getNewlyAllocatedBlockIds(requestId, windowSize);
-        return BlockRange(cacheManager, blockIds, requestId);
-    }
-
     static BlockRange fromNewlyAllocatedBlockIds(BaseKVCacheManager const& cacheManager, LlmRequest const& llmRequest)
     {
         const LlmRequest::RequestIdType requestId = llmRequest.getSeqSlotId(0);

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -862,9 +862,9 @@ public:
             for (std::size_t beam = 0; beam < mTokens.size(); ++beam)
             {
                 auto& beamTokens = mTokens.at(beam);
-                beamTokens.resize(mPromptLen * mNumVocabs);
+                beamTokens.resize(mPromptLen);
                 auto& beamUniqueTokens = mUniqueTokens.at(beam);
-                beamUniqueTokens.resize(mPromptLen * mNumVocabs);
+                beamUniqueTokens.resize(mPromptLen);
                 if (returnLogProbs())
                 {
                     mLogProbs.at(beam).clear();
@@ -877,9 +877,9 @@ public:
             for (std::size_t beam = 0; beam < mTokens.size(); ++beam)
             {
                 auto& beamTokens = mTokens.at(beam);
-                beamTokens.resize(newPromptLen);
+                beamTokens.resize(newPromptLen * mNumVocabs);
                 auto& beamUniqueTokens = mUniqueTokens.at(beam);
-                beamUniqueTokens.resize(newPromptLen);
+                beamUniqueTokens.resize(newPromptLen * mNumVocabs);
 
                 if (returnLogProbs())
                 {

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -130,6 +131,7 @@ public:
         executor::PriorityType priority = executor::Request::kDefaultPriority,
         std::optional<TensorPtr> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<TensorPtr> decoderContextFeatures = std::nullopt,
         std::optional<TensorPtr> crossAttentionMask = std::nullopt,
         LlmRequestType llmRequestType = LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         std::optional<std::shared_ptr<VecTokenExtraIds>> inputTokenExtraIds = std::nullopt,
@@ -139,9 +141,10 @@ public:
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt)
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
+        SizeType32 numVocabs = 1)
         : mRequestId(requestId)
-        , mPromptLen(inputTokens->size())
+        , mPromptLen(inputTokens->size() / numVocabs)
         , mMaxNewTokens(maxNewTokens)
         , mSamplingConfig(samplingConfig)
         , mEndId(endId)
@@ -185,6 +188,7 @@ public:
         , mFinishReasons(samplingConfig.beamWidth)
         , mEncoderInputFeatures(std::move(encoderInputFeatures))
         , mEncoderOutputLength(encoderOutputLength)
+        , mDecoderContextFeatures(std::move(decoderContextFeatures))
         , mCrossAttentionMask(std::move(crossAttentionMask))
         , mLlmRequestType(llmRequestType)
         , mContextPhaseParams(contextPhaseParams)
@@ -197,6 +201,7 @@ public:
         , mLanguageAdapterUid(languageAdapterUid)
         , mAllottedTimeMs(allottedTimeMs)
         , mCacheSaltID(cacheSaltID)
+        , mNumVocabs{numVocabs}
     {
         if (mEncoderTokens.has_value() || encoderInputFeatures.has_value())
         {
@@ -224,9 +229,9 @@ public:
         executor::PriorityType priority = executor::Request::kDefaultPriority, SizeType32 numReturnSequences = 1,
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt)
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, SizeType32 numVocabs = 1)
         : mRequestId(requestId)
-        , mPromptLen(inputTokens.size())
+        , mPromptLen(inputTokens.size() / numVocabs)
         , mMaxNewTokens(maxNewTokens)
         , mSamplingConfig(samplingConfig)
         , mEndId(endId)
@@ -265,6 +270,7 @@ public:
         , mNumReturnSequences(numReturnSequences)
         , mLanguageAdapterUid(languageAdapterUid)
         , mCacheSaltID(cacheSaltID)
+        , mNumVocabs{numVocabs}
     {
         if (mEncoderTokens.has_value())
         {
@@ -275,7 +281,7 @@ public:
 
     GenericLlmRequest(RequestIdType requestId, executor::Request const& req)
         : mRequestId(requestId)
-        , mPromptLen(req.getInputTokenIds().size())
+        , mPromptLen(req.getInputTokenIds().size()/req.getNumVocabs()))
         , mMaxNewTokens(req.getMaxTokens())
         , mSamplingConfig(req.getSamplingConfig(), req.getExternalDraftTokensConfig())
         , mEndId(req.getEndId())
@@ -304,6 +310,7 @@ public:
         , mLanguageAdapterUid(req.getLanguageAdapterUid())
         , mAllottedTimeMs(req.getAllottedTimeMs())
         , mCacheSaltID(req.getCacheSaltID())
+        , mNumVocabs(req.getNumVocabs())
     {
         if (req.getRequestType() == executor::RequestType::REQUEST_TYPE_GENERATION_ONLY)
         {
@@ -437,6 +444,16 @@ public:
             mEncoderInputFeatures = std::nullopt;
         }
 
+        auto const& decoderContextFeatures = req.getDecoderContextFeatures();
+        if (decoderContextFeatures.has_value())
+        {
+            mDecoderContextFeatures = executor::detail::toITensor(decoderContextFeatures.value());
+        }
+        else
+        {
+            mDecoderContextFeatures = std::nullopt;
+        }
+
         auto const& crossAttentionMask = req.getCrossAttentionMask();
         if (crossAttentionMask.has_value())
         {
@@ -512,12 +529,54 @@ public:
         mContextProgress = progress;
     }
 
+    /// @brief Get number of vocabs for this multi vocab sampling
+    /// @return  The number of vocabs
+    [[nodiscard]] SizeType32 getNumVocabs() const
+    {
+        return mNumVocabs;
+    }
+
     /// @brief Get total number of tokens for this req (prompt + generated)
     /// @param beam The beam index
     /// @return  The number of tokens
     [[nodiscard]] SizeType32 getNumTokens(SizeType32 beam) const
     {
-        return mTokens.at(beam).size() - mNumPreDecodedTokens[beam];
+        return mTokens.at(beam).size() / getNumVocabs() - mNumPreDecodedTokens[beam];
+    }
+
+    [[nodiscard]] bool isCfg() const
+    {
+        return mSamplingConfig.cfgScale.has_value() && mSamplingConfig.cfgScale->at(0) != 1.0f;
+    }
+
+    [[nodiscard]] SizeType32 getNumSequences() const
+    {
+        if (isCfg())
+        {
+            TLLM_CHECK_WITH_INFO(mSamplingConfig.beamWidth == 1, "cfgScale is only supported for beamWidth = 1");
+            return 2;
+        }
+        return 1;
+    }
+
+    [[nodiscard]] SizeType32 getSeqSlot(int idx) const
+    {
+        TLLM_CHECK_WITH_INFO(idx >= 0 && idx < getNumSequences(), "seq slot idx is out of range");
+        return mSeqSlots[idx];
+    }
+
+    [[nodiscard]] uint64_t getSeqSlotId(int idx = 0) const
+    {
+        if (idx == 0)
+        {
+            return mRequestId;
+        }
+        if (isCfg() && idx == 1)
+        {
+            return std::numeric_limits<uint64_t>::max() - mRequestId;
+        }
+        TLLM_CHECK_WITH_INFO(false, "Sequence slot id is implemented for CFG only");
+        return 0;
     }
 
     /// @brief Get the number of subrequests, the expected number of responses under non-streaming mode. In sampling
@@ -803,9 +862,9 @@ public:
             for (std::size_t beam = 0; beam < mTokens.size(); ++beam)
             {
                 auto& beamTokens = mTokens.at(beam);
-                beamTokens.resize(mPromptLen);
+                beamTokens.resize(mPromptLen * mNumVocabs);
                 auto& beamUniqueTokens = mUniqueTokens.at(beam);
-                beamUniqueTokens.resize(mPromptLen);
+                beamUniqueTokens.resize(mPromptLen * mNumVocabs);
                 if (returnLogProbs())
                 {
                     mLogProbs.at(beam).clear();
@@ -840,7 +899,7 @@ public:
         mPrepopulatedPromptLenTarget = 0;
         mPrepopulatedPromptLenDraft = 0;
         mContextChunkSize = mPromptLen;
-        mSeqSlot.reset();
+        mSeqSlots, clear();
     }
 
     /// @brief Get the maximum length of tokens returned to the client. Use to ensure we don't return to
@@ -1172,6 +1231,54 @@ public:
     [[nodiscard]] TensorPtr getEncoderInputFeatures() const
     {
         return mEncoderInputFeatures.value_or(nullptr);
+    }
+
+    [[nodiscard]] TensorPtr getDecoderContextFeatures() const
+    {
+        return mDecoderContextFeatures.value_or(nullptr);
+    }
+
+    void setAttentionPriorIdx(SizeType32 attentionPriorIdx, runtime::ModelConfig const& modelConfig)
+    {
+        auto const lastIdx = getEncoderOutputLen() - modelConfig.getAttentionPriorWindowRight() - 1;
+        if (attentionPriorIdx > lastIdx)
+        {
+            // no need to move further the attention window will cover all tokens till end
+            attentionPriorIdx = lastIdx;
+        }
+        mAttentionPriorIdx = attentionPriorIdx;
+        if (mAttentionPriorCounters.size() == 0)
+        {
+            // TODO: lazy initialization due to inconsistencies between
+            // runtime::ITensor::SharedPtr and at::Tensor
+            mAttentionPriorCounters.resize(getEncoderOutputLen(), 0);
+        }
+        mAttentionPriorCounters[attentionPriorIdx]++;
+        if (attentionPriorIdx >= lastIdx)
+        {
+            mAttentionPriorCounterCloseToEnd++;
+        }
+        else if (mAttentionPriorCounters[attentionPriorIdx] >= 8)
+        {
+            // increment to avoid getting stuck in the same encoder output
+            setAttentionPriorIdx(attentionPriorIdx + 1, modelConfig);
+        }
+    }
+
+    bool isAttentionPriorFinished() const
+    {
+        return mAttentionPriorCounterCloseToEnd >= 20;
+    }
+
+    [[nodiscard]] SizeType32 getAttentionPriorIdx(runtime::ModelConfig const& modelConfig)
+    {
+        if (!mAttentionPriorIdx.has_value())
+        {
+            setAttentionPriorIdx(1, modelConfig);
+        }
+        // `setAttentionPriorIdx` takes care to avoid getting stuck in the same encoder output,
+        // it is expected that `mAttentionPriorCounters[mAttentionPriorIdx]` is always < 8
+        return mAttentionPriorIdx.value();
     }
 
     void setEncoderOutputHost(TensorPtr encoderOutputHost)
@@ -1879,7 +1986,7 @@ public:
     runtime::SamplingConfig mSamplingConfig;
     std::optional<TokenIdType> mEndId{std::nullopt};
     std::optional<TokenIdType> mPadId{std::nullopt};
-    std::optional<SizeType32> mSeqSlot{std::nullopt};
+    std::vector<SizeType32> mSeqSlots {}
     std::optional<LogitsPostProcessor> mLogitsPostProcessor{std::nullopt};
     bool mApplyLogitsPostProcessorBatched{false};
     std::optional<RequestIdType> mClientId{std::nullopt};
@@ -1972,6 +2079,13 @@ protected:
     // Encoder input tokens
     std::optional<std::shared_ptr<VecTokens>> mEncoderTokens{std::nullopt};
 
+    // for attention prior, placeholder for where to focus in encoder output
+    std::optional<SizeType32> mAttentionPriorIdx;
+    // counts how many times certain attention prior idx was attended
+    std::vector<SizeType32> mAttentionPriorCounters;
+    // counts how many times attention prior idx is close to the end of sequence
+    SizeType32 mAttentionPriorCounterCloseToEnd{0};
+
     bool mReturnEncoderOutput;
 
     // Encoder output, used to compute cross attention KV-Cache.
@@ -1991,6 +2105,9 @@ protected:
     // Setting buffer sizes correctly for models like Whisper,
     // which encoder output shape cannot be inferred from encoder input shape due to downsampling.
     std::optional<SizeType32> mEncoderOutputLength{std::nullopt};
+
+    // decoder context features to replace the token encodings
+    std::optional<TensorPtr> mDecoderContextFeatures{std::nullopt};
 
     // Input cross attention mask.
     std::optional<TensorPtr> mCrossAttentionMask{std::nullopt};
@@ -2046,6 +2163,8 @@ protected:
 
     // Context request only. The hashes of the blocks that are requested by the corresponding generation request.
     std::vector<size_t> mRequestedBlockHashes;
+
+    SizeType32 mNumVocabs;
 
     bool mIsDummyRequest{false};
 
@@ -2227,6 +2346,7 @@ public:
         executor::PriorityType priority = executor::Request::kDefaultPriority,
         std::optional<TensorPtr> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<TensorPtr> decoderContextFeatures = std::nullopt,
         std::optional<TensorPtr> crossAttentionMask = std::nullopt,
         LlmRequestType llmRequestType = LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         std::optional<VecTokenExtraIds> inputTokenExtraIds = std::nullopt, SizeType32 numReturnSequences = 1,
@@ -2262,7 +2382,7 @@ public:
             encoderInputTokens ? std::make_optional(std::make_shared<VecTokens>(std::move(*encoderInputTokens)))
                                : std::optional<std::shared_ptr<VecTokens>>(std::nullopt),
             returnEncoderOutput, clientId, priority, std::move(encoderInputFeatures), encoderOutputLength,
-            std::move(crossAttentionMask), llmRequestType,
+            std::move(decoderContextFeatures), std::move(crossAttentionMask), llmRequestType,
             inputTokenExtraIds ? std::make_optional(std::make_shared<VecTokenExtraIds>(std::move(*inputTokenExtraIds)))
                                : std::optional<std::shared_ptr<VecTokenExtraIds>>(std::nullopt),
             numReturnSequences, std::move(eagleConfig), skipCrossAttnBlocks, returnPerfMetrics,

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -281,7 +281,7 @@ public:
 
     GenericLlmRequest(RequestIdType requestId, executor::Request const& req)
         : mRequestId(requestId)
-        , mPromptLen(req.getInputTokenIds().size()/req.getNumVocabs()))
+        , mPromptLen(req.getInputTokenIds().size() / req.getNumVocabs())
         , mMaxNewTokens(req.getMaxTokens())
         , mSamplingConfig(req.getSamplingConfig(), req.getExternalDraftTokensConfig())
         , mEndId(req.getEndId())
@@ -899,7 +899,7 @@ public:
         mPrepopulatedPromptLenTarget = 0;
         mPrepopulatedPromptLenDraft = 0;
         mContextChunkSize = mPromptLen;
-        mSeqSlots, clear();
+        mSeqSlots.clear();
     }
 
     /// @brief Get the maximum length of tokens returned to the client. Use to ensure we don't return to
@@ -1986,7 +1986,7 @@ public:
     runtime::SamplingConfig mSamplingConfig;
     std::optional<TokenIdType> mEndId{std::nullopt};
     std::optional<TokenIdType> mPadId{std::nullopt};
-    std::vector<SizeType32> mSeqSlots {}
+    std::vector<SizeType32> mSeqSlots{};
     std::optional<LogitsPostProcessor> mLogitsPostProcessor{std::nullopt};
     bool mApplyLogitsPostProcessorBatched{false};
     std::optional<RequestIdType> mClientId{std::nullopt};

--- a/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
@@ -45,7 +45,8 @@ public:
 
     runtime::CudaEvent operator()(runtime::ModelConfig const& modelConfig, DecoderOutputBuffers& decoderOutputBuffers,
         runtime::BufferManager const& copyBufferManager, runtime::decoder::DecoderState const& decoderState,
-        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent, SizeType32 vocabId = 0) const;
+        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent,
+        tensorrt_llm::runtime::SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
@@ -45,7 +45,7 @@ public:
 
     runtime::CudaEvent operator()(runtime::ModelConfig const& modelConfig, DecoderOutputBuffers& decoderOutputBuffers,
         runtime::BufferManager const& copyBufferManager, runtime::decoder::DecoderState const& decoderState,
-        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent) const;
+        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent, SizeType32 vocabId = 0) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
@@ -45,8 +45,7 @@ public:
 
     runtime::CudaEvent operator()(runtime::ModelConfig const& modelConfig, DecoderOutputBuffers& decoderOutputBuffers,
         runtime::BufferManager const& copyBufferManager, runtime::decoder::DecoderState const& decoderState,
-        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent,
-        tensorrt_llm::runtime::SizeType32 vocabId = 0) const;
+        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -747,8 +747,8 @@ public:
     [[nodiscard]] std::optional<ContextPhaseParams> const& getContextPhaseParams() const;
     [[nodiscard]] std::optional<Tensor> getEncoderInputFeatures() const;
     [[nodiscard]] std::optional<SizeType32> getEncoderOutputLength() const;
-    [[nodiscard]] std::optional<Tensor> getDecoderContextFeatures() const
-        [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const;
+    [[nodiscard]] std::optional<Tensor> getDecoderContextFeatures() const;
+    [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const;
     [[nodiscard]] RequestType getRequestType() const;
     [[nodiscard]] std::optional<EagleConfig> getEagleConfig() const;
     [[nodiscard]] std::optional<Tensor> getSkipCrossAttnBlocks() const;

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -76,7 +76,8 @@ public:
         std::optional<SizeType32> const& noRepeatNgramSize = std::nullopt,
         std::optional<SizeType32> const& numReturnSequences = std::nullopt,
         std::optional<FloatType> const& minP = std::nullopt,
-        std::optional<std::vector<SizeType32>> const& beamWidthArray = std::nullopt);
+        std::optional<std::vector<SizeType32>> const& beamWidthArray = std::nullopt,
+        std::optional<FloatType> const& cfgScale = std::nullopt);
 
     bool operator==(SamplingConfig const& other) const;
 
@@ -100,6 +101,7 @@ public:
     [[nodiscard]] std::optional<SizeType32> getNumReturnSequences() const;
     [[nodiscard]] std::optional<FloatType> getMinP() const;
     [[nodiscard]] std::optional<std::vector<SizeType32>> getBeamWidthArray() const;
+    [[nodiscard]] std::optional<FloatType> getCfgScale() const;
 
     void setBeamWidth(SizeType32 beamWidth);
     void setTopK(std::optional<SizeType32> const& topK);
@@ -120,6 +122,7 @@ public:
     void setNumReturnSequences(std::optional<SizeType32> const& numReturnSequences);
     void setMinP(std::optional<FloatType> const& minP);
     void setBeamWidthArray(std::optional<std::vector<SizeType32>> const& beamWidthArray);
+    void setCfgScale(std::optional<FloatType> const& cfgScale);
 
 private:
     static SizeType32 checkBeamWidth(SizeType32 beamWidth);
@@ -141,6 +144,7 @@ private:
     static std::optional<FloatType> const& checkMinP(std::optional<FloatType> const& minP);
     static std::pair<std::optional<std::vector<SizeType32>> const&, SizeType32 const> const checkBeamWidthArray(
         std::optional<std::vector<SizeType32>> const& beamWidthArray, SizeType32 const beamWidth);
+    static std::optional<FloatType> const& checkCfgScale(std::optional<FloatType> const& cfgScale);
     void updateNumReturnBeams();
 
     friend class Serialization;
@@ -192,6 +196,8 @@ private:
     std::optional<FloatType> mMinP;
     /// @brief Controls the beam width for each step for Variable-Beam-Width-Search.
     std::optional<std::vector<SizeType32>> mBeamWidthArray;
+    /// @brief Controls the cfg scale for sampling.
+    std::optional<FloatType> mCfgScale;
 };
 
 /// @brief Additional output that should be gathered.
@@ -660,6 +666,7 @@ public:
     /// @param encoderInputFeatures Encoder input features for multimodal models.
     /// @param encoderOutputLength Encoder output length if encoder input and output have different lengths (due to
     /// convolution down-sampling, etc.)
+    /// @param decoderContextFeatures Decoder context features for multimodal models.
     /// @param crossAttentionMask Cross attention mask.
     /// @param numReturnSequences The number of returning sequences.
     /// @param eagleConfig The EAGLE speculative decoding configuration
@@ -670,6 +677,7 @@ public:
     /// finish reason. The request may exceed this time slightly, but at most by 1 forward pass (in pipeline parallelism
     /// that may involve multiple micro-batches). A request can be timed-out before ever being scheduled.
     /// @param cacheSaltID Salt ID for KV cache blocks to limit the kv cache reuse to the requests with the same string.
+    /// @param numVocabs The number of vocabs.
     Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming = false,
         SamplingConfig const& samplingConfig = SamplingConfig(), OutputConfig const& outputConfig = OutputConfig(),
         std::optional<SizeType32> const& endId = std::nullopt, std::optional<SizeType32> const& padId = std::nullopt,
@@ -692,12 +700,13 @@ public:
         std::optional<ContextPhaseParams> contextPhaseParams = std::nullopt,
         std::optional<Tensor> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<Tensor> decoderContextFeatures = std::nullopt,
         std::optional<Tensor> crossAttentionMask = std::nullopt, SizeType32 numReturnSequences = 1,
         std::optional<EagleConfig> eagleConfig = std::nullopt, std::optional<Tensor> skipCrossAttnBlocks = std::nullopt,
         std::optional<GuidedDecodingParams> guidedDecodingParams = std::nullopt,
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt);
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, SizeType32 numVocabs = 1);
 
     /// @brief This logits postprocessor name will dispatch to the batched logits postprocessor
     static auto constexpr kBatchedPostProcessorName = "batched";
@@ -738,7 +747,8 @@ public:
     [[nodiscard]] std::optional<ContextPhaseParams> const& getContextPhaseParams() const;
     [[nodiscard]] std::optional<Tensor> getEncoderInputFeatures() const;
     [[nodiscard]] std::optional<SizeType32> getEncoderOutputLength() const;
-    [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const;
+    [[nodiscard]] std::optional<Tensor> getDecoderContextFeatures() const
+        [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const;
     [[nodiscard]] RequestType getRequestType() const;
     [[nodiscard]] std::optional<EagleConfig> getEagleConfig() const;
     [[nodiscard]] std::optional<Tensor> getSkipCrossAttnBlocks() const;
@@ -747,6 +757,7 @@ public:
     [[nodiscard]] std::optional<MillisecondsType> getAllottedTimeMs() const;
     [[nodiscard]] std::optional<CacheSaltIDType> getCacheSaltID() const;
     [[nodiscard]] std::optional<std::vector<std::string>> getAdditionalOutputNames() const;
+    [[nodiscard]] SizeType32 getNumVocabs() const;
 
     void setStreaming(bool streaming);
     void setSamplingConfig(SamplingConfig const& config);
@@ -775,6 +786,7 @@ public:
     void setContextPhaseParams(ContextPhaseParams contextPhaseParams);
     void setEncoderInputFeatures(Tensor encoderInputFeatures);
     void setEncoderOutputLength(SizeType32 encoderOutputLength);
+    void setDecoderContextFeatures(Tensor decoderContextFeatures);
     void setCrossAttentionMask(Tensor crossAttentionMask);
     void setEagleConfig(std::optional<EagleConfig> const& eagleConfig);
     void setSkipCrossAttnBlocks(Tensor skipCrossAttnBlocks);
@@ -782,6 +794,7 @@ public:
     void setLanguageAdapterUid(SizeType32 languageAdapterUid);
     void setAllottedTimeMs(MillisecondsType allottedTimeMs);
     void setCacheSaltID(CacheSaltIDType cacheSaltID);
+    void setNumVocabs(SizeType32 numVocabs);
 
 private:
     friend class Serialization;

--- a/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
+++ b/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
@@ -133,6 +133,11 @@ public:
     {
         return std::vector<runtime::SizeType32>{1};
     }
+
+    [[nodiscard]] __host__ __device__ static constexpr float getCfgScale()
+    {
+        return 1.0f;
+    }
 };
 } // namespace layers
 } // namespace tensorrt_llm

--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -48,7 +48,8 @@ public:
     explicit GptDecoderBatched(CudaStreamPtr stream);
 
     void setup(executor::DecodingMode const& mode, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
-        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig) override;
+        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
+        SizeType32 vocab_size = 0) override;
 
     void disableLookahead(RequestVector const& genRequests, TensorPtr const& batchSlots) override;
 

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -87,7 +87,8 @@ public:
 
     //! @brief Setup the decoder before calling `forward()`
     virtual void setup(executor::DecodingMode const& mode, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
-        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig)
+        nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
+        SizeType32 vocab_size = 0)
         = 0;
 
     //! @brief Disable Lookahead decoding.

--- a/cpp/include/tensorrt_llm/runtime/modelConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/modelConfig.h
@@ -171,7 +171,6 @@ public:
 
     [[nodiscard]] SizeType32 getNumVocabs() const
     {
-        return (mVocabSize + worldSize - 1) / worldSize * worldSize;
         return mVocabSizes ? mVocabSizes.value().size() : 1;
     }
 
@@ -1046,6 +1045,17 @@ private:
 
     // Language adapter info
     std::optional<SizeType32> mNumLanguages;
+
+    // Size of each vocab if there are multiple vocabs
+    std::optional<std::vector<SizeType32>> mVocabSizes;
+    // parameters of attention prior
+    bool mUseAttentionPrior;
+    bool mUseContextEmbeddings;
+    std::vector<SizeType32> mComputeAttentionPriorFromLayers;
+    std::vector<SizeType32> mApplyAttentionPriorToLayers;
+    SizeType32 mAttentionPriorLookahead;
+    SizeType32 mAttentionPriorWindowLeft;
+    SizeType32 mAttentionPriorWindowRight;
 };
 
 } // namespace tensorrt_llm::runtime

--- a/cpp/include/tensorrt_llm/runtime/modelConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/modelConfig.h
@@ -100,7 +100,8 @@ public:
     };
 
     explicit ModelConfig(SizeType32 vocabSize, SizeType32 nbLayers, SizeType32 nbAttentionLayers,
-        SizeType32 nbRnnLayers, SizeType32 nbHeads, SizeType32 hiddenSize, nvinfer1::DataType dtype)
+        SizeType32 nbRnnLayers, SizeType32 nbHeads, SizeType32 hiddenSize, nvinfer1::DataType dtype,
+        std::optional<std::vector<SizeType32>> vocabSizes = std::nullopt)
         : mVocabSize(vocabSize)
         , mNbLayers(nbLayers)
         , mNbAttentionLayers(nbAttentionLayers)
@@ -141,10 +142,20 @@ public:
         , mManageWeightsType(ManageWeightsType::kDisabled)
         , mSkipCrossAttnBlocks(false)
         , mNumLanguages(0)
+        , mVocabSizes{vocabSizes}
+        , mUseAttentionPrior(false)
+        , mUseContextEmbeddings(false)
     {
         TLLM_CHECK_WITH_INFO(mNbLayers >= mNbAttentionLayers + mNbRnnLayers,
             "Number of layers (%d) expected to be >= number of attention (%d) + number of rnn layers (%d)", mNbLayers,
             mNbAttentionLayers, mNbRnnLayers);
+        if (mVocabSizes)
+        {
+            SizeType32 const sizesSum = std::accumulate(mVocabSizes.value().cbegin(), mVocabSizes.value().cend(), 0);
+            TLLM_CHECK_WITH_INFO(
+                sizesSum == vocabSize, "Sum of all vocab sizes (%d) must equal to vocabSize (%d)", sizesSum, vocabSize);
+        }
+
         setNbKvHeads(mNbHeads);
     }
 
@@ -158,9 +169,94 @@ public:
         return mVocabSize;
     }
 
-    [[nodiscard]] SizeType32 constexpr getVocabSizePadded(SizeType32 worldSize) const noexcept
+    [[nodiscard]] SizeType32 getNumVocabs() const
     {
         return (mVocabSize + worldSize - 1) / worldSize * worldSize;
+        return mVocabSizes ? mVocabSizes.value().size() : 1;
+    }
+
+    [[nodiscard]] std::vector<SizeType32> getVocabSizes() const
+    {
+        return mVocabSizes ? *mVocabSizes : std::vector<SizeType32>{mVocabSize};
+    }
+
+    [[nodiscard]] bool constexpr useAttentionPrior() const noexcept
+    {
+        return mUseAttentionPrior;
+    }
+
+    [[nodiscard]] bool constexpr useContextEmbeddings() const noexcept
+    {
+        return mUseContextEmbeddings;
+    }
+
+    void constexpr useAttentionPrior(bool useAttentionPrior) noexcept
+    {
+        mUseAttentionPrior = useAttentionPrior;
+    }
+
+    void constexpr useContextEmbeddings(bool useContextEmbeddings) noexcept
+    {
+        mUseContextEmbeddings = useContextEmbeddings;
+    }
+
+    [[nodiscard]] std::vector<SizeType32> getComputeAttentionPriorFromLayers() const noexcept
+    {
+        return mComputeAttentionPriorFromLayers;
+    }
+
+    [[nodiscard]] std::vector<SizeType32> getApplyAttentionPriorToLayers() const noexcept
+    {
+        return mApplyAttentionPriorToLayers;
+    }
+
+    [[nodiscard]] SizeType32 constexpr getAttentionPriorLookahead() const noexcept
+    {
+        return mAttentionPriorLookahead;
+    }
+
+    [[nodiscard]] SizeType32 constexpr getAttentionPriorWindowLeft() const noexcept
+    {
+        return mAttentionPriorWindowLeft;
+    }
+
+    [[nodiscard]] SizeType32 constexpr getAttentionPriorWindowRight() const noexcept
+    {
+        return mAttentionPriorWindowRight;
+    }
+
+    void setComputeAttentionPriorFromLayers(std::vector<SizeType32> const& computeAttentionPriorFromLayers) noexcept
+    {
+        mComputeAttentionPriorFromLayers = computeAttentionPriorFromLayers;
+    }
+
+    void setApplyAttentionPriorToLayers(std::vector<SizeType32> const& applyAttentionPriorToLayers) noexcept
+    {
+        mApplyAttentionPriorToLayers = applyAttentionPriorToLayers;
+    }
+
+    void constexpr setAttentionPriorLookahead(SizeType32 attentionPriorLookahead) noexcept
+    {
+        mAttentionPriorLookahead = attentionPriorLookahead;
+    }
+
+    void constexpr setAttentionPriorWindowLeft(SizeType32 attentionPriorWindowLeft) noexcept
+    {
+        mAttentionPriorWindowLeft = attentionPriorWindowLeft;
+    }
+
+    void constexpr setAttentionPriorWindowRight(SizeType32 attentionPriorWindowRight) noexcept
+    {
+        mAttentionPriorWindowRight = attentionPriorWindowRight;
+    }
+
+    [[nodiscard]] SizeType32 constexpr getVocabSizePadded(SizeType32 worldSize, SizeType32 vocabSize = 0) const noexcept
+    {
+        if (vocabSize == 0)
+        {
+            vocabSize = mVocabSize;
+        }
+        return (vocabSize + worldSize - 1) / worldSize * worldSize;
     }
 
     [[nodiscard]] SizeType32 countLocalLayers(

--- a/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
+++ b/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
@@ -50,6 +50,7 @@ public:
 
     std::vector<bool>
         promptTuningEnabled; // [batchSize] vector of bool that indicates which requests in a batch have ptuning enabled
+    SizeType32 numVocabs;    // [1], on gpu
 };
 
 class PromptTuningParams : public GenericPromptTuningParams<ITensor::SharedPtr>

--- a/cpp/tensorrt_llm/batch_manager/allocateKvCache.cpp
+++ b/cpp/tensorrt_llm/batch_manager/allocateKvCache.cpp
@@ -30,13 +30,9 @@ void tensorrt_llm::batch_manager::AllocateKvCache::operator()(BaseKVCacheManager
     {
         if (llmReq->isFirstContextChunk())
         {
-            auto const requestId = llmReq->mRequestId;
             auto const promptLen = llmReq->mPromptLen;
             auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
             auto draftLength = llmReq->getNumDraftTokens();
-
-            // Allocate/Reuse KV cache
-            kvCacheManager.addSequence(requestId, promptLen, reqBeamWidth, llmReq);
 
             // EagleNet will increment kv cache up to maxPathLen to account for accepted tokens.
             // Then up to maxDecodingDraftTokens will be used to generate next draft tokens.
@@ -45,26 +41,29 @@ void tensorrt_llm::batch_manager::AllocateKvCache::operator()(BaseKVCacheManager
                 draftLength = modelConfig.getSpeculativeDecodingModule().getMaxPathLen()
                     + modelConfig.getSpeculativeDecodingModule().getMaxDecodingTokens();
             }
-
-            // Allocate more KV cache for speculative decoding
-            if (draftLength > 0)
+            for (int i = 0; i < llmReq->getNumSequences(); i++)
             {
-                for (SizeType32 di = 0; di < draftLength; ++di)
+                auto const requestId = llmReq->getSeqSlotId(i);
+                // Allocate/Reuse KV cache
+                kvCacheManager.addSequence(requestId, promptLen, reqBeamWidth, llmReq);
+                // Allocate more KV cache for speculative decoding
+                if (draftLength > 0)
                 {
-                    kvCacheManager.addToken(requestId);
+                    for (SizeType32 di = 0; di < draftLength; ++di)
+                    {
+                        kvCacheManager.addToken(requestId);
+                    }
                 }
-            }
-
-            if (crossKvCacheManager)
-            {
-                crossKvCacheManager->addSequence(requestId, llmReq->getEncoderOutputLen(), reqBeamWidth, llmReq);
+                if (crossKvCacheManager)
+                {
+                    crossKvCacheManager->addSequence(requestId, llmReq->getEncoderOutputLen(), reqBeamWidth, llmReq);
+                }
             }
         }
     }
 
     for (auto const& llmReq : generationRequests)
     {
-        auto const requestId = llmReq->mRequestId;
         auto decodingTokens = llmReq->getNumDraftTokens() + 1;
 
         // EagleNet will increment kv cache up to maxPathLen to account for accepted tokens.
@@ -75,9 +74,14 @@ void tensorrt_llm::batch_manager::AllocateKvCache::operator()(BaseKVCacheManager
                 + modelConfig.getSpeculativeDecodingModule().getMaxDecodingTokens();
         }
 
-        for (SizeType32 di = 0; di < decodingTokens; ++di)
+        for (int i = 0; i < llmReq->getNumSequences(); i++)
         {
-            kvCacheManager.addToken(requestId);
+
+            auto const requestId = llmReq->getSeqSlotId(i);
+            for (SizeType32 di = 0; di < decodingTokens; ++di)
+            {
+                kvCacheManager.addToken(requestId);
+            }
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
+++ b/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
@@ -35,15 +35,27 @@ void tensorrt_llm::batch_manager::AssignReqSeqSlots::operator()(SequenceSlotMana
                 // Skip assigning sequence slot for DISAGG_GENERATION_INIT request
                 continue;
             }
-            auto const isReqNew = (llmReq->isContextInitState() && !llmReq->mSeqSlot)
+            auto const isReqNew = (llmReq->isContextInitState() && llmReq->mSeqSlots.empty())
                 || (llmReq->isDisaggGenerationTransmissionComplete());
             if (isReqNew && llmReq->getReturnPerfMetrics())
             {
                 llmReq->setFirstScheduledTime();
             }
-            auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->mRequestId);
-            TLLM_CHECK_WITH_INFO(reqSeqSlot, "Unable to get batch slot for request ID %lu", llmReq->mRequestId);
-            llmReq->mSeqSlot = reqSeqSlot;
+
+            for (int i = 0; i < llmReq->getNumSequences(); i++)
+            {
+                auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->getSeqSlotId(i));
+                TLLM_CHECK_WITH_INFO(
+                    reqSeqSlot, "Unable to get batch slot for request ID %lu", llmReq->getSeqSlotId(i));
+                if ((int) llmReq->mSeqSlots.size() >= i + 1)
+                {
+                    llmReq->mSeqSlots[i] = reqSeqSlot.value();
+                }
+                else
+                {
+                    llmReq->mSeqSlots.push_back(reqSeqSlot.value());
+                }
+            }
         }
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -70,7 +70,7 @@ BlockRange getBlockRangeForReceiving(BaseKVCacheManager* cacheManager, LlmReques
         constexpr SizeType32 beam{0};
         return BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId, beam);
     }
-    return BlockRange::fromNewlyAllocatedBlockIds(*cacheManager, llmRequest.mRequestId);
+    return BlockRange::fromNewlyAllocatedBlockIds(*cacheManager, llmRequest);
 }
 
 bool CacheFormatter::needSendCache(

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -44,7 +44,7 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
 {
     size_t requestBlockNum = llmRequest.getRequestedBlockHashes().size();
     constexpr SizeType32 beam{0};
-    auto blockRange = BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId, beam);
+    auto blockRange = BlockRange::fromAllBlockIds(*cacheManager, llmRequest, beam);
     auto poolNum = cacheManager->getBlockManager().getNumPools();
     if (poolNum > 1 || common::getEnvDisableSelectiveCacheTransfer())
     {

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -407,9 +407,14 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
                 // If we can't allocate a started request, we need to start freeing started requests
                 // from the end of the vector and try again
                 // Here we simulate freeing the kvCache blocks associated with that sequence
-                kvCacheManager.schedulingRemoveSequence((*lastStartedReqIt)->mRequestId);
+                for (int i = 0; i < (*lastStartedReqIt)->getNumSequences(); i++)
+                {
+                    auto const requestId = (*lastStartedReqIt)->getSeqSlotId(i);
+                    kvCacheManager.schedulingRemoveSequence((*lastStartedReqIt)->getSeqSlotId(i));
+                    TLLM_LOG_DEBUG(
+                        "MaxUtilizationScheduler: request ID %lu -> pause", (*lastStartedReqIt)->getSeqSlotId(i));
+                }
                 pausedRequests.emplace_back(*lastStartedReqIt);
-                TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu -> pause", (*lastStartedReqIt)->mRequestId);
                 reqItEnd = std::next(lastStartedReqIt).base();
             }
             else

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -75,7 +75,7 @@ void copySequenceLengths(RequestVector const& contextRequests, DecoderInputBuffe
         auto const currentSequenceLen
             = llmReq->mPromptLen + llmReq->getMaxNumGeneratedTokens() + disaggFirstGenTokenSize;
         // Get position of the current sequence in the decoder
-        auto const seqSlot = llmReq->mSeqSlot.value();
+        auto const seqSlot = llmReq->mSeqSlots.at(0);
         batchSlotsRange[batchIdx] = seqSlot;
         fillValuesRange[batchIdx] = currentSequenceLen;
         ++batchIdx;
@@ -661,8 +661,8 @@ CreateNewDecoderRequests::createDecoderRequests(RequestVector const& finishedCon
     {
         llmReq->mSamplingConfig.normalizeLogProbs = mIsNormalizeLogProbs;
 
-        TLLM_CHECK(llmReq->mSeqSlot.has_value());
-        auto const batchSlot = llmReq->mSeqSlot.value();
+        TLLM_CHECK(llmReq->mSeqSlots.at(0));
+        auto const batchSlot = llmReq->mSeqSlots.at(0);
         auto const batchSize = decoderState.getMaxNumSequences();
         TLLM_CHECK(0 <= batchSlot && batchSlot < batchSize);
 

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -710,7 +710,6 @@ CreateNewDecoderRequests::createDecoderRequests(RequestVector const& finishedCon
         initializeLogProbs(dJointOutput, batchSlot, samplingConfig, decoderBufferManager);
 
         auto const& reqTokens = llmReq->getTokens(0);
-        TLLM_LOG_INFO("reqTokens.size(): %d, promptLen: %d, numVocabs: %d", reqTokens.size(), promptLen, numVocabs);
         TLLM_CHECK(reqTokens.size() == static_cast<decltype(reqTokens.size())>(promptLen * numVocabs));
         TensorPtr requestIds = ITensor::slice(inputIds, inputOffset, promptLen);
         // Copy to pinned host memory (don't care about stream of bufferManager)

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -676,6 +676,7 @@ CreateNewDecoderRequests::createDecoderRequests(RequestVector const& finishedCon
         decoderState.setBeamWidth(batchSlot, beamWidth);
 
         auto const promptLen = llmReq->getPromptLen();
+        auto const numVocabs = modelConfig.getNumVocabs();
 
         SizeType32 numDecodingEngineTokens{1};
         if (modelConfig.getSpeculativeDecodingMode().isDraftTokensExternal())
@@ -709,7 +710,8 @@ CreateNewDecoderRequests::createDecoderRequests(RequestVector const& finishedCon
         initializeLogProbs(dJointOutput, batchSlot, samplingConfig, decoderBufferManager);
 
         auto const& reqTokens = llmReq->getTokens(0);
-        TLLM_CHECK(reqTokens.size() == static_cast<decltype(reqTokens.size())>(promptLen));
+        TLLM_LOG_INFO("reqTokens.size(): %d, promptLen: %d, numVocabs: %d", reqTokens.size(), promptLen, numVocabs);
+        TLLM_CHECK(reqTokens.size() == static_cast<decltype(reqTokens.size())>(promptLen * numVocabs));
         TensorPtr requestIds = ITensor::slice(inputIds, inputOffset, promptLen);
         // Copy to pinned host memory (don't care about stream of bufferManager)
         decoderBufferManager.copy(reqTokens.data(), *requestIds);

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -661,7 +661,7 @@ CreateNewDecoderRequests::createDecoderRequests(RequestVector const& finishedCon
     {
         llmReq->mSamplingConfig.normalizeLogProbs = mIsNormalizeLogProbs;
 
-        TLLM_CHECK(llmReq->mSeqSlots.at(0));
+        TLLM_CHECK(!llmReq->mSeqSlots.empty());
         auto const batchSlot = llmReq->mSeqSlots.at(0);
         auto const batchSize = decoderState.getMaxNumSequences();
         TLLM_CHECK(0 <= batchSlot && batchSlot < batchSize);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -691,8 +691,14 @@ public:
         if (!disableSelectiveCacheTransfer)
         {
             auto* cacheManager = mFormatter->getCacheManager();
-            auto blockRange
-                = kv_cache_manager::BlockRange::fromNewlyAllocatedBlockIds(*cacheManager, llmRequest.mRequestId);
+            std::vector<SizeType32> blockIds;
+            for (int i = 0; i < llmRequest.getNumSequences(); i++)
+            {
+                auto const requestId = llmRequest.getSeqSlotId(i);
+                auto const& thisBlockIds = cacheManager->getNewlyAllocatedBlockIds(requestId);
+                blockIds.insert(blockIds.end(), thisBlockIds.begin(), thisBlockIds.end());
+            }
+            auto blockRange = kv_cache_manager::BlockRange(*cacheManager, blockIds);
             requestInfo = RequestInfo(requestId, blockRange.getBlockHashes(), mSelfState);
         }
 

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -691,14 +691,7 @@ public:
         if (!disableSelectiveCacheTransfer)
         {
             auto* cacheManager = mFormatter->getCacheManager();
-            std::vector<SizeType32> blockIds;
-            for (int i = 0; i < llmRequest.getNumSequences(); i++)
-            {
-                auto const requestId = llmRequest.getSeqSlotId(i);
-                auto const& thisBlockIds = cacheManager->getNewlyAllocatedBlockIds(requestId);
-                blockIds.insert(blockIds.end(), thisBlockIds.begin(), thisBlockIds.end());
-            }
-            auto blockRange = kv_cache_manager::BlockRange(*cacheManager, blockIds);
+            auto blockRange = kv_cache_manager::BlockRange::fromNewlyAllocatedBlockIds(*cacheManager, llmRequest);
             requestInfo = RequestInfo(requestId, blockRange.getBlockHashes(), mSelfState);
         }
 

--- a/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
@@ -121,6 +121,11 @@ void EncoderBuffers::updateBufferSizes(RequestVector const& requests, ModelConfi
     {
         encoderInputLen += req->getEncoderInputLen();
         encoderOutputLen += req->getEncoderOutputLen();
+        if (req->isCfg())
+        {
+            // for CFG, repeat the encoder output twice
+            encoderOutputLen += req->getEncoderOutputLen();
+        }
         maxInputLengthInBatch
             = std::max(maxInputLengthInBatch, req->getEncoderInputLen()); // Decoder input is encoder output
     }
@@ -222,40 +227,59 @@ void EncoderBuffers::setFromInputs(RequestVector const& requests, ModelConfig co
     {
         SizeType32 const inputLength = llmReq->getEncoderInputLen();
         SizeType32 const outputLength = llmReq->getEncoderOutputLen();
-        if (llmReq->getEncoderInputFeatures())
+        for (int s = 0; s < llmReq->getNumSequences(); s++)
         {
-            auto const& reqFeatures
-                = llmReq
-                      ->getEncoderInputFeatures(); // whisper: [length, featureDim]; Vision: [batch_size, channel, W, H]
-            TLLM_LOG_DEBUG("EncoderBuffers::setFromInputs - request id = %d, input features length = %d",
-                llmReq->mRequestId, inputLength);
-            manager.copy(*reqFeatures, *ITensor::slice(inputFeatures, offset, inputLength));
-            offset += inputLength;
-        }
-        else
-        {
-            auto const& reqTokens = *llmReq->getEncoderTokens().value();
-            inputIdsAll.insert(inputIdsAll.end(), reqTokens.begin(), reqTokens.end());
-            if (tokenTypeIds)
+            if (llmReq->getEncoderInputFeatures())
             {
-                tokenTypeIdsAll.insert(
-                    tokenTypeIdsAll.end(), tokenTypeIdsReserved.begin(), tokenTypeIdsReserved.begin() + inputLength);
+                if (s == 0)
+                {
+                    // copy input features from request to the buffer for conditional generation
+                    auto const& reqFeatures = llmReq->getEncoderInputFeatures(); // whisper: [length, featureDim];
+                                                                                 // Vision: [batch_size, channel, W, H]
+                    TLLM_LOG_DEBUG("EncoderBuffers::setFromInputs - request id = %d, input features length = %d",
+                        llmReq->mRequestId, inputLength);
+                    manager.copy(*reqFeatures, *ITensor::slice(inputFeatures, offset, inputLength));
+                    offset += inputLength;
+                }
+                else if (s == 1)
+                {
+                    // need to add dummy input of zeros for CFG
+                    auto uncondFeatures = ITensor::slice(inputFeatures, offset, inputLength);
+                    manager.setMem(*uncondFeatures, 0);
+                    offset += inputLength;
+                }
+                else
+                {
+                    TLLM_CHECK_WITH_INFO(
+                        false, "Unexpected sequence index for llmReq [%ld]: %d", llmReq->mRequestId, s);
+                }
             }
+            else
+            {
+                // TODO: CFG support for encoder that processes tokens is not implemented yet
+                auto const& reqTokens = *llmReq->getEncoderTokens().value();
+                inputIdsAll.insert(inputIdsAll.end(), reqTokens.begin(), reqTokens.end());
+                if (tokenTypeIds)
+                {
+                    tokenTypeIdsAll.insert(tokenTypeIdsAll.end(), tokenTypeIdsReserved.begin(),
+                        tokenTypeIdsReserved.begin() + inputLength);
+                }
+            }
+            if (positionIds)
+            {
+                SizeType32 const length = modelConfig.isWhisper() ? outputLength : inputLength;
+                positionIdsAll.insert(
+                    positionIdsAll.end(), positionIdsReserved.begin(), positionIdsReserved.begin() + length);
+            }
+            if (modelConfig.useLanguageAdapter())
+            {
+                auto const languageAdapterRouting
+                    = llmReq->getLanguageAdapterRouting(modelConfig.getNumLanguages().value(), inputLength);
+                languageAdapterRoutingAll.insert(languageAdapterRoutingAll.end(), std::begin(languageAdapterRouting),
+                    std::end(languageAdapterRouting));
+            }
+            inputLengthsAll.push_back(inputLength);
         }
-        if (positionIds)
-        {
-            SizeType32 const length = modelConfig.isWhisper() ? outputLength : inputLength;
-            positionIdsAll.insert(
-                positionIdsAll.end(), positionIdsReserved.begin(), positionIdsReserved.begin() + length);
-        }
-        if (modelConfig.useLanguageAdapter())
-        {
-            auto const languageAdapterRouting
-                = llmReq->getLanguageAdapterRouting(modelConfig.getNumLanguages().value(), inputLength);
-            languageAdapterRoutingAll.insert(
-                languageAdapterRoutingAll.end(), std::begin(languageAdapterRouting), std::end(languageAdapterRouting));
-        }
-        inputLengthsAll.push_back(inputLength);
     }
 
     // copy inputs from host to device
@@ -396,6 +420,10 @@ void EncoderBuffers::rearrangeOutputs(RequestVector const& requests, ModelConfig
             }
         }
         offset += size;
+        if (req->isCfg())
+        {
+            offset += size;
+        }
     }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
@@ -478,16 +506,25 @@ void EncoderBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
 
     for (auto const& llmReq : contextRequests)
     {
-        numRequests += 1;
-        encoderInputLen += llmReq->getEncoderInputLen();
+        numRequests += llmReq->getNumSequences();
         encoderOutputLen += llmReq->getEncoderOutputLen();
+        if (llmReq->isCfg())
+        {
+            encoderInputLen += llmReq->getEncoderInputLen();
+            encoderOutputLen += llmReq->getEncoderOutputLen();
+        }
         maxInputLengthInBatch = std::max(maxInputLengthInBatch, llmReq->getEncoderInputLen());
     }
 
     for (auto const& llmReq : genRequests)
     {
-        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-        numRequests += reqBeamWidth; // tile by beam width
+        encoderOutputLen += llmReq->getEncoderOutputLen();
+        if (llmReq->isCfg())
+        {
+            encoderOutputLen += llmReq->getEncoderOutputLen();
+        }
+        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        numRequests += reqBeamWidth * llmReq->getNumSequences(); // tile by beam width
         maxInputLengthInBatch = std::max(maxInputLengthInBatch, llmReq->getEncoderInputLen());
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
@@ -523,17 +560,26 @@ void EncoderBuffers::fill(
             bool isCtx = llmReq->isContextInitState();
             if (isCtx)
             {
+                // copy encoder output to encoder output buffer for both ctx and gen requests,
+                // disable freeing enc buffer in llm request for it
                 size = llmReq->getEncoderOutputLen();
-                auto const encoderOutputSlice = runtime::ITensor::slice(encoderOutput, offset, size);
+                auto encoderOutputSlice = runtime::ITensor::slice(encoderOutput, offset, size);
                 manager.copy(*llmReq->getEncoderOutput(), *encoderOutputSlice);
                 offset += size;
-
                 inputLengthsAll.emplace_back(size);
+                if (llmReq->isCfg())
+                {
+                    auto encoderOutputSlice = runtime::ITensor::slice(encoderOutput, offset, size);
+                    manager.setMem(*encoderOutputSlice, 0);
+                    offset += size;
+                    inputLengthsAll.emplace_back(size);
+                }
             }
             else
             {
                 auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-                std::fill_n(std::back_inserter(inputLengthsAll), reqBeamWidth,
+                auto const numSeq = llmReq->getNumSequences();
+                std::fill_n(std::back_inserter(inputLengthsAll), reqBeamWidth * numSeq,
                     llmReq->getEncoderOutputLen()); // although encoder output is not needed, gen phase still needs the
                                                     // encoder length info for cross kv cache. Also tile by beam width
             }

--- a/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
+++ b/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
@@ -87,7 +87,7 @@ void GuidedDecoder::build(ScheduledRequests const& scheduledRequests)
                 {
                     continue;
                 }
-                auto const seqSlot = llmReq->mSeqSlot.value();
+                auto const seqSlot = llmReq->mSeqSlots.at(0);
                 if (llmReq->isContextInitState() && llmReq->isFirstContextChunk())
                 {
                     // The request is in the first context forward step (considering kv cache reuse).
@@ -180,7 +180,7 @@ void GuidedDecoder::execute(DecoderInputBuffers const& decoderInputBuffers, Buff
             auto const& guidedDecodingParams = llmReq->getGuidedDecodingParams();
             if (guidedDecodingParams.has_value())
             {
-                auto const seqSlot = llmReq->mSeqSlot.value();
+                auto const seqSlot = llmReq->mSeqSlots.at(0);
 
                 auto const& logits = decoderInputBuffers.logits.at(requestIdx);
                 auto const logitsBitmask = ITensor::at(mLogitsBitmask, {seqSlot});

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -70,8 +70,8 @@ void setupMedusaLogits(std::vector<TensorPtr>& medusaLogitsHeads, TensorPtr cons
 
 SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
     tr::ITensor::SharedPtr const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
-    tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
-    OptionalRef<MedusaBuffers> medusaBuffers) const
+    tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, OptionalRef<MedusaBuffers> medusaBuffers,
+    SizeType32 vocabId) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(HandleContextLogits);
@@ -121,11 +121,31 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
 
         // Get the logits from the last context token and draft tokens
         auto const numDecoderLogits = 1 + draftLength;
-        auto const seqSlot = llmReq->mSeqSlot.value();
+        auto const seqSlot = llmReq->mSeqSlots.at(0);
+
+        // this is CFG support implementation, where we advance the logits index through the unconditional logits
+        if (llmReq->isCfg())
+        {
+            logitsIndex += numContextLogits + draftLength;
+            TensorPtr uncondLogitsView = ITensor::slice(logits, logitsIndex - numDecoderLogits, numDecoderLogits);
+            // TODO: implement CFG, apply logitsView = logitsView * cfgScale + uncondLogitsView * (1 - cfgScale)
+
+            float cfgScale = llmReq->mSamplingConfig.cfgScale->at(0);
+            SizeType32 vocabOffset = 0;
+            auto vocabSizes = modelConfig.getVocabSizes();
+            for (SizeType32 i = 0; i < vocabId; ++i)
+            {
+                vocabOffset += vocabSizes[i];
+            }
+            tensorrt_llm::kernels::invokeCfg(
+                stream, logitsView, uncondLogitsView, cfgScale, vocabOffset, vocabSizes[vocabId]);
+        }
+
         TensorPtr logitsView = ITensor::slice(logits, logitsIndex - numDecoderLogits, numDecoderLogits);
 
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
+            // speculative decoding is not supported for numVocabs > 1
             auto& medusaLogitsHeads = inputBuffers.predictedDraftLogits.at(seqSlot);
             TLLM_CHECK(medusaBuffers);
             setupMedusaLogits(medusaLogitsHeads, medusaBuffers->medusaLogitsDevice,
@@ -161,12 +181,33 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
             {
                 decoderLogits = logitsView;
                 decoderLogits->unsqueeze(1);
+
+                auto curVocablogitsView = logitsView;
+                if (logitsViewShape.d[0] == 1) // if current nTok is 1, could have multiple vocabs
+                {
+                    SizeType32 offset = 0;
+                    auto vocabSizes = modelConfig.getVocabSizes();
+                    for (SizeType32 i = 0; i < vocabId; ++i)
+                    {
+                        offset += vocabSizes[i];
+                    }
+                    curVocablogitsView = ITensor::slice(logitsView, {0, offset}, vocabSizes[vocabId]); // [vocabSize,]
+                    curVocablogitsView
+                        = ITensor::view(curVocablogitsView, ITensor::makeShape({1, vocabSizes[vocabId]}));
+                }
+                auto const updateLogitsViewShape = curVocablogitsView->getShape();
+                decoderLogits = ITensor::view(curVocablogitsView,
+                    ITensor::makeShape({updateLogitsViewShape.d[0], 1, updateLogitsViewShape.d[1]}));
             }
             decoderRequests.push_back(llmReq);
             allDecoderLogits.emplace_back(std::move(decoderLogits));
         }
 
         ++batchIndex;
+        if (llmReq->isCfg())
+        {
+            ++batchIndex;
+        }
     }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -563,12 +563,13 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
-    std::optional<BaseAgentConfig> agentConfig)
+    std::optional<BaseAgentConfig> agentConfig, SizeType32 numVocabs)
     : mNumLayers{static_cast<SizeType32>(numKvHeadsPerLayer.size())}
     , mTokensPerBlock{tokensPerBlock}
     , mEventManager{std::move(eventManager)}
     , mStream{stream}
     , mCacheType{cacheType}
+    , mNumVocabs{numVocabs}
 {
     if (agentConfig.has_value())
         mLoopbackAgent = makeLoopbackAgent("nixl", &agentConfig.value());
@@ -788,9 +789,10 @@ void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest co
     {
         auto cacheBlockIds = sequence.getCacheBlockIds(windowSize);
         auto const& uniqueTokens = llmRequest.getUniqueTokens(beamIdx);
+        auto const numVocabs = llmRequest.getNumVocabs();
 
-        auto blockedUniqueTokens
-            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size() - 1, getTokensPerBlock(), false);
+        auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(
+            uniqueTokens, uniqueTokens.size() - numVocabs, getTokensPerBlock() * numVocabs, false);
         auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
         storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx], windowSize);
     }
@@ -1089,8 +1091,9 @@ void WindowBlockManager::offloadBlock(
 std::optional<BlockKey> WindowBlockManager::findNewContextBlock(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
+    auto const numVocabs = llmRequest.getNumVocabs();
     auto blockedUniqueTokens
-        = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size(), mTokensPerBlock, false);
+        = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size(), mTokensPerBlock * numVocabs, false);
     auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
     BlockKey ret;
     ret.loraTaskId = llmRequest.getLoraTaskId();
@@ -1137,7 +1140,7 @@ SizeType32 WindowBlockManager::loadOrAllocateBlocks(std::vector<BlockKey> const&
         {
             KVCacheBlock::IdType matchingBlockId = matchingBlock->getBlockId();
 
-            numMatchedTokens += numMatched > 0 ? numMatched : blockItr->uniqueTokens.size();
+            numMatchedTokens += numMatched > 0 ? numMatched : blockItr->uniqueTokens.size() / mNumVocabs;
             if (perBlockRetentions[bi].retentionPriority.has_value()
                 && matchingBlock->getPriority() != perBlockRetentions[bi].retentionPriority && mEventManager)
             {
@@ -1278,7 +1281,9 @@ void WindowBlockManager::addSequence(
         : *(llmRequest.getEncoderUniqueTokens().value());
 
     // Ignore last token because it can't be recovered
-    auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, inputLength - 1, mTokensPerBlock, true);
+    auto const numVocabs = llmRequest.getNumVocabs();
+    auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(
+        uniqueTokens, (inputLength - 1) * numVocabs, mTokensPerBlock * numVocabs, true);
     // Add empty block if last token is separated
     if (inputLength % mTokensPerBlock == 1)
     {
@@ -1305,7 +1310,8 @@ void WindowBlockManager::addSequence(
     TLLM_CHECK(perBlockRetentions.size() == (size_t) numContextBlocks);
 
     auto const prepopulatedPromptLen
-        = loadOrAllocateBlocks(blockKeys, numContextBlocks, sequence, perBlockRetentions, mode, directory);
+        = loadOrAllocateBlocks(blockKeys, numContextBlocks, sequence, perBlockRetentions, mode, directory) / numVocabs;
+
     mReusedTokens += static_cast<double>(prepopulatedPromptLen);
     mTotalInputTokens += static_cast<double>(uniqueTokens.size());
 
@@ -1319,7 +1325,7 @@ void WindowBlockManager::addSequence(
 
     llmRequest.setPrepopulatedPromptLen(prepopulatedPromptLen + numConnectorMatchedTokens, getTokensPerBlock());
     TLLM_LOG_DEBUG("addSequence: Request %lu, inputLength %d, prepopulatedPromptLen %d, numConnectorMatchedTokens %d",
-        llmRequest.mRequestId, inputLength, prepopulatedPromptLen, numConnectorMatchedTokens);
+        llmRequest.getSeqSlotId(), inputLength, prepopulatedPromptLen, numConnectorMatchedTokens);
 }
 
 void BlockManager::adjustBlocksIfNeeded(GenerationRequest& sequence, bool isEnableBlockReuse)
@@ -1479,7 +1485,8 @@ SizeType32 WindowBlockManager::storeBlocks(
             TLLM_LOG_DEBUG("%s::storeBlocks - No match, inserting block %d into search structure", mLogPrefix.c_str(),
                 block->getBlockId());
             needMatch = false; // no matching needed for following blocks
-            block->setBlockKey(blockKey, static_cast<SizeType32>(blockKey.uniqueTokens.size()) == mTokensPerBlock);
+            block->setBlockKey(
+                blockKey, static_cast<SizeType32>(blockKey.uniqueTokens.size()) == mTokensPerBlock * mNumVocabs);
             block->setPrevBlock(searchRoot);
             block->setPrevBlockInSeq(searchRoot);
             searchRoot->addNextBlock(blockKey, block);
@@ -1711,11 +1718,13 @@ void WindowBlockManager::releaseBlocks(GenerationRequest& sequence, OptionalRef<
     {
         // If llmRequest is provided, store the blocks for reuse.
         auto const& uniqueTokens = llmRequest->getUniqueTokens(/*beamIdx=*/0);
+        auto const numVocabs = llmRequest->getNumVocabs();
         // Only (length - 1) tokens of the sequence have their kv-state
         // recorded in kv-cache. We assume the last token's state is not filled yet.
-        auto const usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - 1;
+        auto const usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - numVocabs;
         auto blockedUniqueTokens
-            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock, /*allowPartial=*/true);
+            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock * numVocabs,
+                /*allowPartial=*/true);
         auto blockKeys = buildBlockKeys(blockedUniqueTokens, *llmRequest);
 
         std::vector<KVCacheBlock::IdType> cacheBlockIds(allocatedBlocks.size());
@@ -1772,11 +1781,12 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
     std::optional<TempAttentionWindowInputs> const& tempAttentionWindowInputs, nvinfer1::DataType dtype,
     SizeType32 sinkTokenLength, int64_t stream, runtime::SizeType32 maxSequenceLength, bool enableBlockReuse,
-    bool onboardBlocks, CacheType cacheType, bool enablePartialReuse, bool copyOnPartialReuse)
+    bool onboardBlocks, CacheType cacheType, bool enablePartialReuse, bool copyOnPartialReuse, SizeType32 numVocabs)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
-        enableBlockReuse, onboardBlocks, cacheType, std::nullopt, nullptr, enablePartialReuse, copyOnPartialReuse)
+        enableBlockReuse, onboardBlocks, cacheType, std::nullopt, nullptr, enablePartialReuse, copyOnPartialReuse,
+        numVocabs)
 {
 }
 
@@ -1787,12 +1797,12 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     SizeType32 sinkTokenLength, int64_t stream, runtime::SizeType32 maxSequenceLength, bool enableBlockReuse,
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
-    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager)
+    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, SizeType32 numVocabs)
     : KVCacheManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences, maxBeamWidth,
         maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
         enableBlockReuse, onboardBlocks, cacheType, secondaryOffloadMinPriority, eventManager, enablePartialReuse,
-        copyOnPartialReuse, kvCacheConnectorManager)
+        copyOnPartialReuse, kvCacheConnectorManager, numVocabs)
 {
 }
 
@@ -1803,7 +1813,7 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     SizeType32 sinkTokenLength, CudaStreamPtr stream, runtime::SizeType32 maxSequenceLength, bool enableBlockReuse,
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
-    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager)
+    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, SizeType32 numVocabs)
     : mMaxBeamWidth(maxBeamWidth)
     , mDataType(dtype)
     , mMaxAttentionWindow(*std::max_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
@@ -1813,7 +1823,7 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     , mBlockManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
           std::move(stream), maxSequenceLength, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype,
           mSinkBubbleLength, onboardBlocks, cacheType, secondaryOffloadMinPriority, std::move(eventManager),
-          enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager))
+          enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager), numVocabs)
     // disable block reuse for sink bubble since chopVectorIntoBlocks does not match KV cache blocks in this case
     , mEnableBlockReuse{mSinkBubbleLength > 0 ? false : enableBlockReuse}
 {
@@ -1837,11 +1847,11 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     SizeType32 sinkTokenLength, CudaStreamPtr stream, runtime::SizeType32 maxSequenceLength, bool enableBlockReuse,
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
-    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager)
+    std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, SizeType32 numVocabs)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::move(stream), maxSequenceLength, enableBlockReuse, onboardBlocks, cacheType, secondaryOffloadMinPriority,
-        std::move(eventManager), enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager))
+        std::move(eventManager), enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager), numVocabs)
 {
 }
 
@@ -1942,7 +1952,8 @@ SizeType32 KVCacheManager::getNeededBlocksOneStep(
         auto const numUnSharedBlocks
             = tc::ceilDiv(numUnSharedTokens, getTokensPerBlock()) * req.mSamplingConfig.beamWidth;
         auto const numRequiredBlocks = numSharedBlocks + numUnSharedBlocks;
-        return numRequiredBlocks;
+        // we need more blocks if there are multiple sequences in this request
+        return numRequiredBlocks * req.getNumSequences();
     }
 
     if (req.isGenerationInProgressState())
@@ -1980,7 +1991,7 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
     {
         if (req.isContextInitState() && req.getContextCurrentPosition() == 0)
         {
-            return tc::ceilDiv(req.getEncoderOutputLen(), getTokensPerBlock());
+            return tc::ceilDiv(req.getEncoderOutputLen(), getTokensPerBlock()) * req.getNumSequences();
         }
 
         return 0; // cross KV cache doesn't grow after the initial context phase
@@ -1988,23 +1999,26 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
 
     auto const temporaryAttentionWindow = mBlockManager.getWindowSizeMetadata(windowSize).temporaryAttentionWindow;
 
-    SizeType32 const numContextBlocks
-        = (std::min(req.mPromptLen, windowSize + temporaryAttentionWindow) + mSinkBubbleLength) / getTokensPerBlock();
-
-    SizeType32 const numTotalBlocksPerBeam = tc::ceilDiv(
-        std::min(req.mPromptLen + req.mMaxNewTokens, windowSize + temporaryAttentionWindow) + mSinkBubbleLength,
-        getTokensPerBlock());
+    SizeType32 const numContextBlocks = req.getNumSequences()
+        * (std::min(req.mPromptLen, windowSize + temporaryAttentionWindow) + mSinkBubbleLength) / getTokensPerBlock();
+    SizeType32 const numTotalBlocksPerBeam = req.getNumSequences()
+        * tc::ceilDiv(
+            std::min(req.mPromptLen + req.mMaxNewTokens, windowSize + temporaryAttentionWindow) + mSinkBubbleLength,
+            getTokensPerBlock());
 
     SizeType32 const numGenBlocksPerBeam = numTotalBlocksPerBeam - numContextBlocks;
 
     SizeType32 numAllocBlocksPerBeam = 0;
     {
         std::scoped_lock lck(mSequencesMtx);
-        auto const seqIt = mSequences.find(req.mRequestId);
-        if (seqIt != mSequences.end())
+        for (int i = 0; i < req.getNumSequences(); i++)
         {
-            auto const& seq = seqIt->second;
-            numAllocBlocksPerBeam = seq.getCacheBlockIds(windowSize).at(0).size();
+            auto const seqIt = mSequences.find(req.getSeqSlotId(i));
+            if (seqIt != mSequences.end())
+            {
+                auto const& seq = seqIt->second;
+                numAllocBlocksPerBeam += seq.getCacheBlockIds(windowSize).at(0).size();
+            }
         }
     }
 
@@ -2197,18 +2211,21 @@ void KVCacheManager::addSequence(
 
 void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
 {
-    auto const requestId = llmRequest.mRequestId;
-    if (mSequences.find(requestId) != mSequences.end())
+    for (int i = 0; i < llmRequest.getNumSequences(); i++)
     {
-        auto& sequence = getSequence(requestId);
-        if (mEnableBlockReuse && !llmRequest.isDummyRequest())
+        auto const requestId = llmRequest.getSeqSlotId(i);
+        if (mSequences.find(requestId) != mSequences.end())
         {
-            mBlockManager.storeContextBlocks(sequence, llmRequest);
+            auto& sequence = getSequence(requestId);
+            if (mEnableBlockReuse && !llmRequest.isDummyRequest())
+            {
+                mBlockManager.storeContextBlocks(sequence, llmRequest);
+            }
         }
-    }
-    else
-    {
-        TLLM_LOG_WARNING("[kv cache manager] storeContextBlocks: Can not find sequence for request %lu", requestId);
+        else
+        {
+            TLLM_LOG_WARNING("[kv cache manager] storeContextBlocks: Can not find sequence for request %lu", requestId);
+        }
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -604,7 +604,7 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
         mWindowBlockManagers.try_emplace(windowSize, dtype, windowSize, layersWithWindowSize, numKvHeadsPerLayer,
             sizePerHead, tokensPerBlock, /*isSWA=*/windowSize < maxSequenceLength, allottedPrimaryBlocks,
             allottedSecondaryBlocks, maxNumSequences, stream, onboardBlocks, cacheType, secondaryOffloadMinPriority,
-            mEventManager, enablePartialReuse, copyOnPartialReuse, kvCacheConnectorManager, mLoopbackAgent);
+            mEventManager, enablePartialReuse, copyOnPartialReuse, kvCacheConnectorManager, numVocabs, mLoopbackAgent);
     }
 
     auto const numAllPools = getNumPools();

--- a/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
@@ -135,12 +135,12 @@ std::optional<executor::Result> LlmRequest::createResult(bool useFastLogits, int
     for (SizeType32 beam = 0; beam < nbBeams; ++beam)
     {
         auto const& tokens = getTokens(beam);
-        auto const nbTokensOut = calculateNbTokensOut(tokens.size());
+        auto const nbTokensOut = calculateNbTokensOut(tokens.size() / getNumVocabs());
 
         if (nbTokensOut > 0)
         {
-            auto const first = tokens.data() + startTokenPos;
-            result.outputTokenIds.at(beam).assign(first, first + nbTokensOut);
+            auto const first = tokens.data() + startTokenPos * getNumVocabs();
+            result.outputTokenIds.at(beam).assign(first, first + nbTokensOut * getNumVocabs());
         }
     }
 
@@ -322,7 +322,7 @@ std::shared_ptr<LlmRequest> LlmRequest::createChildRequest(RequestIdType request
     childReq->mSequenceIndex = mChildRequests.size() + 1;
     childReq->mParentRequestId = this->mRequestId;
     childReq->mSequenceFinalVec = this->mSequenceFinalVec;
-    childReq->mSeqSlot.reset();
+    childReq->mSeqSlots.clear();
 
     // To ensure different randomness across children, assign a unique random seed to each child
     // by adding its sequence index to the base seed. If no seed is provided, the parent's seed defaults to 0.

--- a/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
+++ b/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
@@ -49,7 +49,8 @@ bool LogitsPostProcessor::operator()(DecoderInputBuffers& inputBuffers, bool rep
     for (size_t batchIdx = 0; batchIdx < inputBuffers.decoderRequests.size(); ++batchIdx)
     {
         auto const& llmReq = inputBuffers.decoderRequests.at(batchIdx);
-        auto& logits = inputBuffers.logits.at(batchIdx);
+        auto& logits = inputBuffers.logits.at(
+            batchIdx); // Check if this should be ...at(llmReq->mSeqSlots.at(0)) instead for CFG
 
         // Invoke non-batched processor or collect arguments for batched processor
         if (llmReq->mLogitsPostProcessor)

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -90,7 +90,7 @@ std::pair<std::vector<SizeType32>, std::vector<SizeType32>> getActiveSlots(Reque
     std::vector<SizeType32> generationSteps;
     for (auto const& llmReq : decoderRequests)
     {
-        activeSlots.push_back(llmReq->mSeqSlot.value());
+        activeSlots.push_back(llmReq->mSeqSlots.at(0));
         generationSteps.push_back(llmReq->getDecodingIter());
     }
 

--- a/cpp/tensorrt_llm/batch_manager/rnnStateBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnStateBuffers.cpp
@@ -51,7 +51,9 @@ void RnnStateBuffers::fillSlotMappings(
     SizeType32 batchIdx{0};
     for (auto const& llmReq : contextRequests)
     {
-        auto const seqSlot = llmReq->mSeqSlot.value();
+        // TODO: rnn state does not support CFG yet
+        TLLM_CHECK_WITH_INFO(!llmReq->isCfg(), "rnn state buffers do not support CFG yet");
+        auto const seqSlot = llmReq->mSeqSlots.at(0);
         auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
         rnnStateManager->fillSlotMapping(*slotMappingHost, batchIdx, seqSlot, reqBeamWidth);
         ++batchIdx;

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -407,7 +407,7 @@ void RuntimeBuffers::reshape(TllmRuntime const& runtime, ModelConfig const& mode
     seqSlotsDevice->reshape(numRequestsShape);
 
     auto const numTokens = getNumTokens();
-    inputsIds->reshape(ITensor::makeShape({numTokens modelConfig.getNumVocabs()}));
+    inputsIds->reshape(ITensor::makeShape({numTokens * modelConfig.getNumVocabs()}));
 
     if (modelConfig.useMrope())
     {

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -738,6 +738,10 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
                         if (llmReq->getNumVocabs() > 1)
                         {
                             auto const& beamTokens = llmReq->getTokens(beam);
+                            TLLM_LOG_INFO(
+                                "llmReq->getNumTokens(beam): %d, numTokens: %d, beamTokens.size(): %d, "
+                                "llmReq->getNumVocabs(): %d",
+                                llmReq->getNumTokens(beam), numTokens, beamTokens.size(), llmReq->getNumVocabs());
                             TLLM_CHECK_WITH_INFO(beamTokens.size() % llmReq->getNumVocabs() == 0,
                                 "Number of tokens needs to be a multiple of number of vocabs!");
                             inputHost.insert(
@@ -1097,6 +1101,7 @@ std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorM
     fillIOMaps(modelConfig, worldConfig);
 
     auto const numTokens = getNumTokens();
+    TLLM_LOG_INFO("[RuntimeBuffers::prepareStep] numTokens: %d", numTokens);
     auto const optProfileId = runtime.getOptProfileId(numTokens, ModelConfig::getOptProfilesSplitPoints());
     setContextIndex(optProfileId);
     TLLM_LOG_DEBUG("numTokens: %d, optProfileId: %d", numTokens, optProfileId);

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -79,6 +79,10 @@ void RuntimeBuffers::create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
+    useAttentionPrior = modelConfig.useAttentionPrior();
+    useContextEmbeddings = modelConfig.useContextEmbeddings();
+    attentionPriorLookahead = modelConfig.getAttentionPriorLookahead();
+
     auto const& manager = runtime.getBufferManager();
     auto const& engine = runtime.getEngine();
 
@@ -117,6 +121,20 @@ void RuntimeBuffers::create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
     logitsIdsHost = manager.emptyTensor(MemoryType::kCPU, nvinfer1::DataType::kINT32);
 
     inputsIds = manager.emptyTensor(MemoryType::kGPU, nvinfer1::DataType::kINT32);
+
+    if (useAttentionPrior)
+    {
+        // probs in attention kernel are in full precision
+        attentionPriorScores = manager.emptyTensor(MemoryType::kGPU, nvinfer1::DataType::kFLOAT);
+        attentionPriorFocus = manager.emptyTensor(MemoryType::kGPU, nvinfer1::DataType::kINT32);
+    }
+
+    if (useContextEmbeddings)
+    {
+        auto const featsType = engine.getTensorDataType(kDecoderContextFeaturesTensorName);
+        decoderContextFeatures = manager.emptyTensor(MemoryType::kGPU, featsType);
+        decoderContextFeaturesMask = manager.emptyTensor(MemoryType::kGPU, nvinfer1::DataType::kBOOL);
+    }
 
     if (worldConfig.isPipelineParallel())
     {
@@ -246,17 +264,21 @@ void RuntimeBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
     NVTX3_SCOPED_RANGE(runtimeBuffersSetBufferSizes);
 
     // set context sizes
-    numContextRequests = static_cast<SizeType32>(contextRequests.size());
+    numContextRequests = 0;
+    for (auto const& llmReq : contextRequests)
+    {
+        numContextRequests += llmReq->getNumSequences();
+    }
     auto numContextLogits = numContextRequests;
     numContextTokens = 0;
     maxContextLength = 0;
     for (auto const& llmReq : contextRequests)
     {
         auto const draftLength = llmReq->isLastContextChunk() ? llmReq->getNumDraftTokens() : 0;
-        numContextLogits += draftLength;
+        numContextLogits += draftLength * llmReq->getNumSequences();
 
         auto const contextChunkSize = llmReq->getContextChunkSize();
-        numContextTokens += contextChunkSize + draftLength;
+        numContextTokens += (contextChunkSize + draftLength) * llmReq->getNumSequences();
         if (maxContextLength < llmReq->mPromptLen)
         {
             maxContextLength = llmReq->mPromptLen;
@@ -264,15 +286,19 @@ void RuntimeBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
     }
 
     // set generation sizes
-    numGenRequests = static_cast<SizeType32>(genRequests.size());
+    numGenRequests = 0;
+    for (auto const& llmReq : genRequests)
+    {
+        numGenRequests += llmReq->getNumSequences();
+    }
     numGenSequences = 0;
     numGenTokens = 0;
     for (auto const& llmReq : genRequests)
     {
         auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-        numGenSequences += reqBeamWidth;
+        numGenSequences += reqBeamWidth * llmReq->getNumSequences();
         auto const draftLen = llmReq->getNumDraftTokens();
-        numGenTokens += draftLen + reqBeamWidth;
+        numGenTokens += (draftLen + reqBeamWidth) * llmReq->getNumSequences();
     }
 
     numLogits = numContextLogits + numGenTokens;
@@ -381,7 +407,7 @@ void RuntimeBuffers::reshape(TllmRuntime const& runtime, ModelConfig const& mode
     seqSlotsDevice->reshape(numRequestsShape);
 
     auto const numTokens = getNumTokens();
-    inputsIds->reshape(ITensor::makeShape({numTokens}));
+    inputsIds->reshape(ITensor::makeShape({numTokens modelConfig.getNumVocabs()}));
 
     if (modelConfig.useMrope())
     {
@@ -416,6 +442,18 @@ void RuntimeBuffers::reshape(TllmRuntime const& runtime, ModelConfig const& mode
         tensor->reshape(shape);
     }
 
+    if (useAttentionPrior)
+    {
+        attentionPriorScores->reshape(ITensor::makeShape({attentionPriorLookahead * getNumSequences()}));
+        attentionPriorFocus->reshape(ITensor::makeShape({getNumSequences()}));
+    }
+
+    if (useContextEmbeddings)
+    {
+        decoderContextFeatures->reshape(ITensor::makeShape({numTokens, modelConfig.getHiddenSize()}));
+        decoderContextFeaturesMask->reshape(ITensor::makeShape({numTokens}));
+        runtime.getBufferManager().setMem(*decoderContextFeaturesMask, 0);
+    }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
@@ -491,9 +529,11 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
             for (auto const& llmReq : requests)
             {
                 // Get position of the current sequence in the decoder
-                auto const seqSlot = llmReq->mSeqSlot.value();
-                seqSlotIndices[batchIdx] = seqSlot;
-                ++batchIdx;
+                for (auto const& seqSlot : llmReq->mSeqSlots)
+                {
+                    seqSlotIndices[batchIdx] = seqSlot;
+                    ++batchIdx;
+                }
             }
         }
 
@@ -501,11 +541,17 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
         manager.copy(*seqSlots, *seqSlotsDevice);
     }
 
+    SizeType32 contextRequestsSize = 0;
+    for (auto const& llmReq : contextRequests)
+    {
+        contextRequestsSize += llmReq->getNumSequences();
+    }
+
     // context preparation loop
-    if (!contextRequests.empty())
+    if (contextRequestsSize > 0)
     {
         NVTX3_SCOPED_RANGE(contextPrepareLoop);
-        numContextLogits.resize(contextRequests.size());
+        numContextLogits.resize(contextRequestsSize);
 
         SizeType32 batchIdx{0};
         for (auto const& llmReq : contextRequests)
@@ -516,202 +562,266 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
                 llmReq->getMaxNumGeneratedTokens() == 0, "Context request should not have generated tokens.");
 
             auto const& reqTokens = llmReq->getTokens(0);
-            auto const& draftTokens = llmReq->getDraftTokens();
-            auto const draftLength = llmReq->getNumDraftTokens();
-            auto const& positionIds = llmReq->getPositionIds();
-
-            auto const contextChunkSize = llmReq->getContextChunkSize();
-            auto const beginCompute = llmReq->getContextCurrentPosition();
-            auto const endCompute = beginCompute + contextChunkSize;
-            inputHost.insert(inputHost.end(), reqTokens.begin() + beginCompute, reqTokens.begin() + endCompute);
-
-            logitsIdsHostPtr[totalNumLogits++] = contextChunkSize;
-            numContextLogits.at(batchIdx) = modelConfig.computeContextLogits() ? contextChunkSize : 1;
-
-            if (llmReq->isLastContextChunk())
+            // for CFG requests, add the inputs to the buffer twice
+            std::vector<bool> is_conditional_vec{true};
+            if (llmReq->isCfg())
             {
-                inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
-                std::fill_n(logitsIdsHostPtr + totalNumLogits, draftLength, 1);
-                totalNumLogits += draftLength;
+                is_conditional_vec.push_back(false);
             }
-            auto const inputLength = contextChunkSize + (llmReq->isLastContextChunk() ? draftLength : 0);
-            contextLengthsHostPtr[batchIdx] = inputLength;
-            auto const sequenceLen = inputLength + llmReq->getContextCurrentPosition();
-            sequenceLengthsHostPtr[batchIdx] = sequenceLen;
-
-            if (static_cast<bool>(pastKeyValueLengthsPtr))
+            for (auto const& is_conditional : is_conditional_vec)
             {
-                pastKeyValueLengthsPtr[batchIdx] = beginCompute + inputLength;
-            }
-
-            if (positionIds.has_value())
-            {
-                TLLM_CHECK_WITH_INFO(!(isChatGlm || isGlm), "ChatGLM-6B and Glm only use the default initialization");
-                positionIdsHost.insert(positionIdsHost.end(), positionIds.value()->begin() + beginCompute,
-                    positionIds.value()->begin() + endCompute);
-            }
-            else
-            {
-                if (isChatGlm)
+                auto const& origTokens = llmReq->getTokens(0);
+                std::vector<TokenIdType> dummyTokens;
+                if (!is_conditional)
                 {
-                    // Specialize for ChatGLM-6B with 2D-Position-Embedding
-                    positionIdsHost.resize(totalInputSize + inputLength);
-                    std::iota(std::begin(positionIdsHost) + totalInputSize, std::end(positionIdsHost), 0);
-                    positionIdsHost.back() = positionIdsHost.back() - 1;
-
-                    positionIdsHostRow2.resize(totalInputSize + inputLength);
-                    positionIdsHostRow2.back() = 1;
+                    // that is special token added in "convert_checkpoint",
+                    // that is expanded to all zeros
+                    dummyTokens.assign(origTokens.size(), modelConfig.getVocabSize());
                 }
-                else if (isGlm)
+
+                auto const& reqTokens = is_conditional ? origTokens : dummyTokens;
+                auto const& draftTokens = llmReq->getDraftTokens();
+                auto const draftLength = llmReq->getNumDraftTokens();
+                auto const& positionIds = llmReq->getPositionIds();
+
+                auto const contextChunkSize = llmReq->getContextChunkSize();
+                auto const beginCompute = llmReq->getContextCurrentPosition();
+                auto const endCompute = beginCompute + contextChunkSize;
+                inputHost.insert(inputHost.end(), reqTokens.begin() + beginCompute,
+                    reqTokens.begin() + beginCompute + contextChunkSize * llmReq->getNumVocabs());
+
+                logitsIdsHostPtr[totalNumLogits++] = contextChunkSize;
+                numContextLogits.at(batchIdx) = modelConfig.computeContextLogits() ? contextChunkSize : 1;
+
+                if (llmReq->isLastContextChunk())
                 {
-                    // Specialize for GLM-10B with 2D-Position-Embedding and special value of the mask id position
-                    auto start = inputHost.begin() + totalInputSize;
-                    auto end = start + inputLength;
-                    auto it = std::find_if(
-                        start, end, [](SizeType32 id) { return id == 50260 || id == 50263 || id == 50264; });
-                    llmReq->mMaskPosition = (it != end) ? std::distance(start, it) : maxContextLength;
+                    inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
+                    std::fill_n(logitsIdsHostPtr + totalNumLogits, draftLength, 1);
+                    totalNumLogits += draftLength;
+                }
+                auto const inputLength = contextChunkSize + (llmReq->isLastContextChunk() ? draftLength : 0);
+                contextLengthsHostPtr[batchIdx] = inputLength;
+                auto const sequenceLen = inputLength + llmReq->getContextCurrentPosition();
+                sequenceLengthsHostPtr[batchIdx] = sequenceLen;
 
-                    positionIdsHost.resize(totalInputSize + inputLength);
-                    std::iota(std::begin(positionIdsHost) + totalInputSize, std::end(positionIdsHost), 0);
-                    positionIdsHost.back() = llmReq->mMaskPosition;
+                if (static_cast<bool>(pastKeyValueLengthsPtr))
+                {
+                    pastKeyValueLengthsPtr[batchIdx] = beginCompute + inputLength;
+                }
 
-                    positionIdsHostRow2.resize(totalInputSize + inputLength);
-                    positionIdsHostRow2.back() = 1;
+                if (positionIds.has_value())
+                {
+                    TLLM_CHECK_WITH_INFO(
+                        !(isChatGlm || isGlm), "ChatGLM-6B and Glm only use the default initialization");
+                    positionIdsHost.insert(positionIdsHost.end(), positionIds.value()->begin() + beginCompute,
+                        positionIds.value()->begin() + endCompute);
                 }
                 else
                 {
-                    // Other models
-                    positionIdsHost.resize(totalInputSize + inputLength);
-                    std::iota(std::begin(positionIdsHost) + totalInputSize,
-                        std::begin(positionIdsHost) + totalInputSize + inputLength, beginCompute);
-                }
-            }
-            if (modelConfig.useMrope())
-            {
-                auto optMropeRotaryCosSin = llmReq->getMropeRotaryCosSin().value();
-                TLLM_CHECK_WITH_INFO(optMropeRotaryCosSin->getShape().d[0] == mropeRotaryCosSinSize,
-                    "Provided MropeRotarySinCos is %ld and expected is %d.\n", optMropeRotaryCosSin->getShape().d[0],
-                    int(mropeRotaryCosSinSize));
-
-                auto const mropeRotaryCosSinCtx = ITensor::slice(mropeRotaryCosSin, batchIdx, 1);
-                manager.copy(*optMropeRotaryCosSin, *mropeRotaryCosSinCtx);
-            }
-
-            if (modelConfig.useLanguageAdapter())
-            {
-                auto const languageAdapterRouting = llmReq->getLanguageAdapterRouting(
-                    modelConfig.getNumLanguages().value(), endCompute - beginCompute);
-                languageAdapterRoutingsHost.insert(languageAdapterRoutingsHost.end(),
-                    std::begin(languageAdapterRouting), std::end(languageAdapterRouting));
-            }
-            totalInputSize += inputLength;
-            ++batchIdx;
-        }
-
-        if (rnnStateBuffers)
-        {
-            rnnStateBuffers->fillSlotMappings(contextRequests, rnnStateManagerPtr);
-        }
-    }
-
-    // generation preparation loop
-    if (!genRequests.empty())
-    {
-        NVTX3_SCOPED_RANGE(genPrepareLoop);
-
-        auto const numContextRequests = static_cast<SizeType32>(contextRequests.size());
-        auto numSequences = numContextRequests;
-        for (auto const& llmReq : genRequests)
-        {
-            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-            auto const draftLength = llmReq->getNumDraftTokens();
-            auto const& draftTokens = llmReq->getDraftTokens();
-            auto const numLogits = draftLength + reqBeamWidth;
-            TLLM_CHECK(draftLength == 0 || reqBeamWidth == 1);
-
-            auto const promptLen = llmReq->mPromptLen;
-            auto const sequenceLen
-                = promptLen + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
-            auto const& positionIds = llmReq->getPositionIds();
-            for (int beam = 0; beam < reqBeamWidth; ++beam)
-            {
-                auto const numTokens = llmReq->getNumTokens(beam) + static_cast<SizeType32>(trtOverlap);
-                // TODO: can this be removed completely?
-                if (!trtOverlap)
-                {
-                    auto const lastToken = llmReq->getLastTokens(beam);
-                    inputHost.push_back(lastToken);
-                    if (draftLength > 0)
+                    if (isChatGlm)
                     {
-                        inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
+                        // Specialize for ChatGLM-6B with 2D-Position-Embedding
+                        positionIdsHost.resize(totalInputSize + inputLength);
+                        std::iota(std::begin(positionIdsHost) + totalInputSize, std::end(positionIdsHost), 0);
+                        positionIdsHost.back() = positionIdsHost.back() - 1;
+
+                        positionIdsHostRow2.resize(totalInputSize + inputLength);
+                        positionIdsHostRow2.back() = 1;
                     }
-                }
-
-                // If model updates generation position ids do not append them here.
-                if (!modelConfig.getSpeculativeDecodingMode().updatesPositionIds())
-                {
-                    if (positionIds.has_value())
+                    else if (isGlm)
                     {
-                        TLLM_CHECK_WITH_INFO(
-                            !(isChatGlm || isGlm), "ChatGLM-6B and Glm only use the default initialization");
-                        auto last_context_position_id = positionIds.value()->back();
-                        positionIdsHost.push_back(
-                            static_cast<SizeType32>(last_context_position_id + sequenceLen - promptLen));
+                        // Specialize for GLM-10B with 2D-Position-Embedding and special value of the mask id position
+                        auto start = inputHost.begin() + totalInputSize;
+                        auto end = start + inputLength;
+                        auto it = std::find_if(
+                            start, end, [](SizeType32 id) { return id == 50260 || id == 50263 || id == 50264; });
+                        llmReq->mMaskPosition = (it != end) ? std::distance(start, it) : maxContextLength;
+
+                        positionIdsHost.resize(totalInputSize + inputLength);
+                        std::iota(std::begin(positionIdsHost) + totalInputSize, std::end(positionIdsHost), 0);
+                        positionIdsHost.back() = llmReq->mMaskPosition;
+
+                        positionIdsHostRow2.resize(totalInputSize + inputLength);
+                        positionIdsHostRow2.back() = 1;
                     }
                     else
                     {
-                        if (isChatGlm) // ChatGLM-6B
-                        {
-                            positionIdsHost.push_back(static_cast<SizeType32>(promptLen - 2));
-                            positionIdsHostRow2.push_back(static_cast<SizeType32>(sequenceLen - promptLen + 1));
-                        }
-                        else if (isGlm)
-                        {
-                            positionIdsHost.push_back(llmReq->mMaskPosition);
-                            positionIdsHostRow2.push_back(static_cast<SizeType32>(sequenceLen - promptLen + 1));
-                        }
-                        else // GPT / ChatGLM2-6B / ChatGLM3-6B / BART
-                        {
-                            // positionIds is just the size of tokens -1
-                            positionIdsHost.push_back(numTokens - 1);
-                        }
+                        // Other models
+                        positionIdsHost.resize(totalInputSize + inputLength);
+                        std::iota(std::begin(positionIdsHost) + totalInputSize,
+                            std::begin(positionIdsHost) + totalInputSize + inputLength, beginCompute);
                     }
                 }
-
                 if (modelConfig.useMrope())
                 {
-                    auto optMropePositionDeltas = llmReq->getMropePositionDeltas().value();
-                    mropePositionDeltasHost.push_back(optMropePositionDeltas);
+                    auto optMropeRotaryCosSin = llmReq->getMropeRotaryCosSin().value();
+                    TLLM_CHECK_WITH_INFO(optMropeRotaryCosSin->getShape().d[0] == mropeRotaryCosSinSize,
+                        "Provided MropeRotarySinCos is %ld and expected is %d.\n",
+                        optMropeRotaryCosSin->getShape().d[0], int(mropeRotaryCosSinSize));
+
+                    auto const mropeRotaryCosSinCtx = ITensor::slice(mropeRotaryCosSin, batchIdx, 1);
+                    manager.copy(*optMropeRotaryCosSin, *mropeRotaryCosSinCtx);
                 }
 
                 if (modelConfig.useLanguageAdapter())
                 {
-                    // Generation requests only have one token per sequence
-                    auto const languageAdapterRouting
-                        = llmReq->getLanguageAdapterRouting(modelConfig.getNumLanguages().value(), 1);
+                    auto const languageAdapterRouting = llmReq->getLanguageAdapterRouting(
+                        modelConfig.getNumLanguages().value(), endCompute - beginCompute);
                     languageAdapterRoutingsHost.insert(languageAdapterRoutingsHost.end(),
                         std::begin(languageAdapterRouting), std::end(languageAdapterRouting));
                 }
+                totalInputSize += inputLength;
+                ++batchIdx;
             }
+        }
 
-            if (static_cast<bool>(pastKeyValueLengthsPtr))
+        if (rnnStateBuffers)
+        {
+            // TODO: dont implement CFG for rnn state buffers for now
+            rnnStateBuffers->fillSlotMappings(contextRequests, rnnStateManagerPtr);
+        }
+
+        // set decoder context features and mask
+        if (useContextEmbeddings)
+        {
+            SizeType32 tokenIdx = 0;
+            for (auto const& llmReq : contextRequests)
             {
-                SizeType32 pastKeyValueLength = sequenceLen - 1;
-                std::fill_n(pastKeyValueLengthsPtr + numSequences, reqBeamWidth, pastKeyValueLength);
+                auto const contextPosition = llmReq->getContextCurrentPosition();
+                auto const contextChunkSize = llmReq->getContextChunkSize();
+                if (llmReq->getDecoderContextFeatures())
+                {
+                    auto const& reqFeatures = llmReq->getDecoderContextFeatures();
+                    TLLM_CHECK_WITH_INFO(contextPosition + contextChunkSize <= reqFeatures->getShape().d[0],
+                        "Decoder context features [%d, %d], but request is at position %d and chunk size %d",
+                        (int) reqFeatures->getShape().d[0], (int) reqFeatures->getShape().d[1], contextPosition,
+                        contextChunkSize);
+                    // specifying offset and size across 0th dimension
+                    manager.copy(*ITensor::slice(reqFeatures, contextPosition, contextChunkSize),
+                        *ITensor::slice(decoderContextFeatures, tokenIdx, contextChunkSize));
+                    manager.setMem(*ITensor::slice(decoderContextFeaturesMask, tokenIdx, contextChunkSize), 1);
+                }
+                tokenIdx += llmReq->getNumSequences() * contextChunkSize;
             }
-            totalInputSize += numLogits;
+        }
+    }
 
-            std::fill_n(logitsIdsHostPtr + totalNumLogits, numLogits, 1);
+    // generation preparation loop - CHECK THIS LINE ONWARDS
+    if (!genRequests.empty())
+    {
+        NVTX3_SCOPED_RANGE(genPrepareLoop);
 
-            totalNumLogits += numLogits;
+        auto numSequences = contextRequestsSize;
 
-            if (rnnStateBuffers)
+        for (auto const& llmReq : genRequests)
+        {
+            for (int s = 0; s < llmReq->getNumSequences(); s++)
             {
-                auto const seqSlot = llmReq->mSeqSlot.value();
-                auto& rnnStateManager = *rnnStateManagerPtr;
-                rnnStateManager.fillSlotMapping(*rnnStateBuffers->slotMappingHost, numSequences, seqSlot, reqBeamWidth);
+                auto reqBeamWidth = llmReq->getBeamWidthByIter();
+                auto const draftLength = llmReq->getNumDraftTokens();
+                auto const& draftTokens = llmReq->getDraftTokens();
+                auto const numLogits = draftLength + reqBeamWidth;
+                TLLM_CHECK(draftLength == 0 || reqBeamWidth == 1);
+
+                auto const promptLen = llmReq->mPromptLen;
+                auto const sequenceLen
+                    = promptLen + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
+                auto const& positionIds = llmReq->getPositionIds();
+                for (int reqBeam = 0; reqBeam < reqBeamWidth; ++reqBeam)
+                {
+                    // for CFG, simply use tokens from the 0th beam during generation
+                    int beam = llmReq->isCfg() ? 0 : reqBeam;
+                    auto const numTokens = llmReq->getNumTokens(beam) + static_cast<SizeType32>(trtOverlap);
+                    // TODO: can this be removed completely?
+                    if (!trtOverlap)
+                    {
+                        if (llmReq->getNumVocabs() > 1)
+                        {
+                            auto const& beamTokens = llmReq->getTokens(beam);
+                            TLLM_CHECK_WITH_INFO(beamTokens.size() % llmReq->getNumVocabs() == 0,
+                                "Number of tokens needs to be a multiple of number of vocabs!");
+                            inputHost.insert(
+                                inputHost.end(), beamTokens.cend() - llmReq->getNumVocabs(), beamTokens.cend());
+                        }
+                        else
+                        {
+                            auto const lastToken = llmReq->getLastTokens(beam);
+                            inputHost.push_back(lastToken);
+                        }
+                        if (draftLength > 0)
+                        {
+                            inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
+                        }
+                    }
+
+                    // If model updates generation position ids do not append them here.
+                    if (!modelConfig.getSpeculativeDecodingMode().updatesPositionIds())
+                    {
+                        if (positionIds.has_value())
+                        {
+                            TLLM_CHECK_WITH_INFO(
+                                !(isChatGlm || isGlm), "ChatGLM-6B and Glm only use the default initialization");
+                            auto last_context_position_id = positionIds.value()->back();
+                            positionIdsHost.push_back(
+                                static_cast<SizeType32>(last_context_position_id + sequenceLen - promptLen));
+                        }
+                        else
+                        {
+                            if (isChatGlm) // ChatGLM-6B
+                            {
+                                positionIdsHost.push_back(static_cast<SizeType32>(promptLen - 2));
+                                positionIdsHostRow2.push_back(static_cast<SizeType32>(sequenceLen - promptLen + 1));
+                            }
+                            else if (isGlm)
+                            {
+                                positionIdsHost.push_back(llmReq->mMaskPosition);
+                                positionIdsHostRow2.push_back(static_cast<SizeType32>(sequenceLen - promptLen + 1));
+                            }
+                            else // GPT / ChatGLM2-6B / ChatGLM3-6B / BART
+                            {
+                                // positionIds is just the size of tokens -1
+                                positionIdsHost.push_back(numTokens - 1);
+                            }
+                        }
+                    }
+
+                    if (modelConfig.useMrope())
+                    {
+                        auto optMropePositionDeltas = llmReq->getMropePositionDeltas().value();
+                        mropePositionDeltasHost.push_back(optMropePositionDeltas);
+                    }
+
+                    if (modelConfig.useLanguageAdapter())
+                    {
+                        // Generation requests only have one token per sequence
+                        auto const languageAdapterRouting
+                            = llmReq->getLanguageAdapterRouting(modelConfig.getNumLanguages().value(), 1);
+                        languageAdapterRoutingsHost.insert(languageAdapterRoutingsHost.end(),
+                            std::begin(languageAdapterRouting), std::end(languageAdapterRouting));
+                    }
+                }
+
+                if (static_cast<bool>(pastKeyValueLengthsPtr))
+                {
+                    SizeType32 pastKeyValueLength = sequenceLen - 1;
+                    std::fill_n(pastKeyValueLengthsPtr + numSequences, reqBeamWidth, pastKeyValueLength);
+                }
+                totalInputSize += numLogits;
+
+                std::fill_n(logitsIdsHostPtr + totalNumLogits, numLogits, 1);
+
+                totalNumLogits += numLogits;
+
+                if (rnnStateBuffers)
+                {
+                    TLLM_CHECK_WITH_INFO(!llmReq->isCfg(), "CFG is not supported for rnn state buffers");
+                    auto const seqSlot = llmReq->mSeqSlots[0];
+                    auto& rnnStateManager = *rnnStateManagerPtr;
+                    rnnStateManager.fillSlotMapping(
+                        *rnnStateBuffers->slotMappingHost, numSequences, seqSlot, reqBeamWidth);
+                }
+                numSequences += reqBeamWidth;
             }
-            numSequences += reqBeamWidth;
         }
 
         if (transformerBuffers && maxBeamWidth > 1)
@@ -719,25 +829,45 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
             transformerBuffers->copyCacheIndirection(genRequests, decoderState.getCacheIndirectionOutput(), stream);
         }
 
-        numSequences = numContextRequests;
+        numSequences = contextRequestsSize;
         for (auto const& llmReq : genRequests)
         {
-            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-            auto const draftLength = llmReq->getNumDraftTokens();
+            for (int s = 0; s < llmReq->getNumSequences(); s++)
+            {
+                auto const reqBeamWidth = llmReq->getBeamWidthByIter();
+                auto const draftLength = llmReq->getNumDraftTokens();
 
-            auto const contextQLength = llmReq->mPromptLen + draftLength;
-            auto const sequenceLen
-                = contextQLength + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
+                auto const contextQLength = llmReq->mPromptLen + draftLength;
+                auto const sequenceLen
+                    = contextQLength + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
 
-            std::fill_n(contextLengthsHostPtr + numSequences, reqBeamWidth, contextQLength);
-            std::fill_n(sequenceLengthsHostPtr + numSequences, reqBeamWidth, sequenceLen);
-            numSequences += reqBeamWidth;
+                std::fill_n(contextLengthsHostPtr + numSequences, reqBeamWidth, contextQLength);
+                std::fill_n(sequenceLengthsHostPtr + numSequences, reqBeamWidth, sequenceLen);
+                numSequences += reqBeamWidth;
+            }
         }
+
         if (modelConfig.getSpeculativeDecodingMode().isLookaheadDecoding())
         {
             // copy from lookahead decoding buffer
             mLookaheadBuffers->setFromInputs(numContextRequests, numGenRequests, *requestTypes, *seqSlots,
                 decoderState.getLookaheadBuffers(), runtime, modelConfig, worldConfig);
+        }
+
+        if (useAttentionPrior)
+        {
+            // set to zero attention prior scores, so scores from different layers can be accumulated
+            manager.setMem(*attentionPriorScores, 0);
+            // copy focus indices from llm requests to a buffer
+            std::vector<int> focus_lst(numContextRequests, 0);
+            for (auto const& llmReq : genRequests)
+            {
+                for (SizeType32 i = 0; i < llmReq->getNumSequences(); i++)
+                {
+                    focus_lst.push_back(llmReq->getAttentionPriorIdx(modelConfig));
+                }
+            }
+            manager.copy(focus_lst.data(), *attentionPriorFocus, runtime::MemoryType::kCPU);
         }
     }
 
@@ -901,6 +1031,51 @@ void RuntimeBuffers::prepareEagleBuffers(RequestVector const& contextRequests, R
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
+void RuntimeBuffers::processAttentionPriorScores(
+    RequestVector const& genRequests, TllmRuntime const& runtime, ModelConfig const& modelConfig)
+{
+    /**
+     * is called after inference is done. processes the "scores" buffer and sets up
+     * the index with most attention focus for each request.
+     */
+    if (!useAttentionPrior)
+    {
+        TLLM_LOG_WARNING("processing attention prior scores, when attention prior is disabled");
+        return;
+    }
+
+    // copy scores to host
+    auto const& manager = runtime.getBufferManager();
+    auto const& stream = runtime.getStream();
+    auto scoresHost
+        = manager.cpu(ITensor::makeShape({getNumSequences() * attentionPriorLookahead}), nvinfer1::DataType::kFLOAT);
+    manager.copy(*attentionPriorScores, *scoresHost);
+    stream.synchronize();
+
+    // for each generation request, analyze scores and set the attention prior idx
+    size_t scoresOffset = numContextRequests * attentionPriorLookahead;
+    auto* scoresHostPtr = bufferCast<float>(*scoresHost);
+    for (auto const& llmReq : genRequests)
+    {
+        size_t prevPriorIdx = llmReq->getAttentionPriorIdx(modelConfig);
+        float maxScore = scoresHostPtr[scoresOffset];
+        int idxShift = 0;
+        for (int i = 1; i < attentionPriorLookahead; i++)
+        {
+            if (scoresHostPtr[scoresOffset + i] > maxScore)
+            {
+                maxScore = scoresHostPtr[scoresOffset + i];
+                idxShift = i;
+            }
+        }
+
+        llmReq->setAttentionPriorIdx(prevPriorIdx + idxShift, modelConfig);
+
+        // TODO: remove hardcode of lookahead size
+        scoresOffset += attentionPriorLookahead * llmReq->getNumSequences();
+    }
+}
+
 std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorMap&> RuntimeBuffers::prepareStep(
     RequestVector const& contextRequests, RequestVector const& genRequests, SizeType32 maxBeamWidth,
     SizeType32 maxAttentionWindow, runtime::decoder::DecoderState const& decoderState,
@@ -974,6 +1149,15 @@ void RuntimeBuffers::fillIOMaps(ModelConfig const& modelConfig, WorldConfig cons
     inputMap.insert_or_assign(kHostContextLengthsTensorName, contextLengthsHost);
     inputMap.insert_or_assign(kSequenceLengthsTensorName, sequenceLengthsDevice);
 
+    if (useContextEmbeddings)
+    {
+        inputMap.insert_or_assign(kDecoderContextFeaturesTensorName, decoderContextFeatures);
+        inputMap.insert_or_assign(kDecoderContextFeaturesMaskTensorName, decoderContextFeaturesMask);
+    }
+    if (useAttentionPrior)
+    {
+        inputMap.insert_or_assign(kAttentionPriorFocusTensorName, attentionPriorFocus);
+    }
     if (modelConfig.useCrossAttention())
     {
         encoderBuffers->insertInputTensors(inputMap);
@@ -1016,6 +1200,10 @@ void RuntimeBuffers::fillIOMaps(ModelConfig const& modelConfig, WorldConfig cons
     if (mEagleBuffers)
     {
         mEagleBuffers->insertInputTensors(inputMap, outputMap, worldConfig);
+    }
+    if (useAttentionPrior)
+    {
+        outputMap.insert_or_assign(kAttentionPriorScoresTensorName, attentionPriorScores);
     }
 
     for (auto const& outputTensor : mAdditionalOutputTensors)

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -738,10 +738,6 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
                         if (llmReq->getNumVocabs() > 1)
                         {
                             auto const& beamTokens = llmReq->getTokens(beam);
-                            TLLM_LOG_INFO(
-                                "llmReq->getNumTokens(beam): %d, numTokens: %d, beamTokens.size(): %d, "
-                                "llmReq->getNumVocabs(): %d",
-                                llmReq->getNumTokens(beam), numTokens, beamTokens.size(), llmReq->getNumVocabs());
                             TLLM_CHECK_WITH_INFO(beamTokens.size() % llmReq->getNumVocabs() == 0,
                                 "Number of tokens needs to be a multiple of number of vocabs!");
                             inputHost.insert(
@@ -1101,7 +1097,6 @@ std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorM
     fillIOMaps(modelConfig, worldConfig);
 
     auto const numTokens = getNumTokens();
-    TLLM_LOG_INFO("[RuntimeBuffers::prepareStep] numTokens: %d", numTokens);
     auto const optProfileId = runtime.getOptProfileId(numTokens, ModelConfig::getOptProfilesSplitPoints());
     setContextIndex(optProfileId);
     TLLM_LOG_DEBUG("numTokens: %d, optProfileId: %d", numTokens, optProfileId);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2107,7 +2107,6 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
     for (SizeType32 vid = 0; vid < getNumVocabs(); vid++)
     {
         auto& decoderInputBuffers = mDecoderInputBuffers.at(getFusedBufferId());
-        auto& decoderOutputBuffers = mDecoderOutputBuffers[vid].at(getFusedBufferId());
         auto& decoderState = mDecoderStates[vid];
 
         auto const contextBufferId = mCtxGenFusion ? getFusedBufferId() : getContextBufferId();

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2432,7 +2432,8 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
 
         // Terminate if request has finished or if it is speculative decoding target model
         if (decoderFinishedSumPtr[seqSlot] == reqBeamWidth
-            || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens()))
+            || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens())
+            || (mModelConfig.useAttentionPrior() && llmReq->isAttentionPriorFinished()))
         {
             postProcessRequest(*llmReq, numDroppedTokens);
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -351,7 +351,8 @@ private:
     /// @brief Copies the content of the cache indirection outputs to the cache indirection inputs.
     /// @param[in] scheduledRequests The requests to copy the cache indirections for.
     /// @param[in] genBufferId The id of the generation buffers for those requests.
-    void copyCacheIndirectionFromOutputsToInputs(ScheduledRequests const& scheduledRequests, SizeType32 genBufferId);
+    void copyCacheIndirectionFromOutputsToInputs(
+        ScheduledRequests const& scheduledRequests, SizeType32 genBufferId, SizeType32 vocabId);
 
     [[nodiscard]] bool getGatherGenerationLogits() const override
     {
@@ -587,7 +588,7 @@ private:
     // PEFT table for each micro batch
     std::vector<PeftTable> mPeftTables;
     // Decoder input for each micro batch.
-    std::vector<std::unique_ptr<runtime::decoder_batch::Input>> mDecodingInputs;
+    std::vector<std::vector<std::unique_ptr<runtime::decoder_batch::Input>>> mDecodingInputs;
 
     /******************** Book keeping ********************/
     // List of requests in each micro batch

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -461,6 +461,21 @@ protected:
 
     SizeType32 getMaxCapacityBatchSize(SizeType32 inputLength, SizeType32 outputLength) const override;
 
+    [[nodiscard]] SizeType32 getNumVocabs() const
+    {
+        return mModelConfig.getNumVocabs();
+    }
+
+    [[nodiscard]] std::vector<SizeType32> getVocabSizes() const
+    {
+        return mModelConfig.getVocabSizes();
+    }
+
+    [[nodiscard]] SizeType32 getVocabSize() const
+    {
+        return mModelConfig.getVocabSize();
+    }
+
 private:
     /******************** Configs ********************/
     // Parameters of the model (TRT engine)
@@ -484,9 +499,12 @@ private:
     // Runner for the TRT engine. The engine produces logits.
     std::unique_ptr<runtime::TllmRuntime> mRuntime;
     // Decoder that generates new tokens from the logits.
-    std::unique_ptr<runtime::GptDecoderBatched> mDecoder;
+
+    std::vector<std::unique_ptr<runtime::GptDecoderBatched>> mDecoders;
     // Decoder state for all requests
-    std::unique_ptr<runtime::decoder::DecoderState> mDecoderState;
+    // std::unique_ptr<runtime::decoder::DecoderState> mDecoderState;
+    // Decoder state for all requests
+    std::vector<std::unique_ptr<runtime::decoder::DecoderState>> mDecoderStates;
     // Synchronization handles for decoder
     std::vector<std::optional<runtime::CudaEvent>> mDecoderFinishedEvents;
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -582,7 +582,7 @@ private:
     // Decoder input buffers for each micro batch.
     std::vector<DecoderInputBuffers> mDecoderInputBuffers;
     // Decoder output buffers for each micro batch.
-    std::vector<DecoderOutputBuffers> mDecoderOutputBuffers;
+    std::vector<std::vector<DecoderOutputBuffers>> mDecoderOutputBuffers;
     // Buffers for each slot in the decoder
     std::vector<std::unique_ptr<SlotDecoderBuffers>> mSlotDecoderBuffers;
     // PEFT table for each micro batch

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -115,6 +115,12 @@ struct FusedQKVMaskedAttentionDispatchParams
     KVCacheBuffer kv_block_array;
     KVLinearBuffer shift_k_cache_buffer;
     bool cross_attention = false;
+    float* attention_prior_scores = nullptr;
+    int const* attention_prior_focus = nullptr;
+    bool apply_attention_prior = false;
+    int attention_prior_lookahead = 5;
+    int attention_prior_window_left = 1;
+    int attention_prior_window_right = 5;
     int const* memory_length_per_sample = nullptr;
     int max_distance = 0;
     bool block_sparse_attention = false;
@@ -630,6 +636,17 @@ void fusedQKV_masked_attention_dispatch(Multihead_attention_params<T_MMHA, CROSS
     // Attention mask input.
     params.attention_mask = input_params.attention_mask;
     params.attention_mask_stride = input_params.attention_mask_stride;
+
+    // forward attention prior params only if its a cross attention
+    if (CROSS_ATTENTION)
+    {
+        params.attention_prior_scores = input_params.attention_prior_scores;
+        params.attention_prior_focus = input_params.attention_prior_focus;
+        params.apply_attention_prior = input_params.apply_attention_prior;
+        params.attention_prior_lookahead = input_params.attention_prior_lookahead;
+        params.attention_prior_window_left = input_params.attention_prior_window_left;
+        params.attention_prior_window_right = input_params.attention_prior_window_right;
+    }
 
     // Attention sinks.
     params.attention_sinks = input_params.attention_sinks;
@@ -2406,6 +2423,18 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     dispatch_params.rotary_cogvlm_vision_start = mVisionStart;
     dispatch_params.rotary_cogvlm_vision_length = mVisionLength;
     dispatch_params.cross_attention = isCrossAttention();
+    if (ComputeAttentionPrior())
+    {
+        dispatch_params.attention_prior_scores = params.attention_prior_scores;
+        dispatch_params.attention_prior_lookahead = mAttentionPriorLookahead;
+        dispatch_params.attention_prior_window_left = mAttentionPriorWindowLeft;
+        dispatch_params.attention_prior_window_right = mAttentionPriorWindowRight;
+    }
+    if (ApplyAttentionPrior() || ComputeAttentionPrior())
+    {
+        dispatch_params.attention_prior_focus = params.attention_prior_focus;
+        dispatch_params.apply_attention_prior = mApplyAttentionPrior;
+    }
     dispatch_params.memory_length_per_sample = params.encoder_input_lengths;
     dispatch_params.block_sparse_attention = mMaskType == AttentionMaskType::BLOCKSPARSE;
     dispatch_params.block_sparse_params = mBlockSparseParams;
@@ -2967,6 +2996,11 @@ std::string AttentionOp::toString() const
     ss << "mMaxContextLength: " << mMaxContextLength << std::endl;
     ss << "mQKVBiasEnabled: " << std::boolalpha << mQKVBiasEnabled << std::endl;
     ss << "mCrossAttention: " << std::boolalpha << mCrossAttention << std::endl;
+    ss << "mComputeAttentionPrior: " << std::boolalpha << mComputeAttentionPrior << std::endl;
+    ss << "mApplyAttentionPrior: " << std::boolalpha << mApplyAttentionPrior << std::endl;
+    ss << "mAttentionPriorLookahead: " << mAttentionPriorLookahead << std::endl;
+    ss << "mAttentionPriorWindowLeft: " << mAttentionPriorWindowLeft << std::endl;
+    ss << "mAttentionPriorWindowRight: " << mAttentionPriorWindowRight << std::endl;
     ss << "mMaxDistance: " << mMaxDistance << std::endl;
     ss << "mPosShiftEnabled: " << std::boolalpha << mPosShiftEnabled << std::endl;
     ss << "mPagedContextFMHA: " << std::boolalpha << mPagedContextFMHA << std::endl;

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -219,6 +219,10 @@ public:
         int32_t spec_decoding_max_generation_length = 1;
         // optional when fuse_fp4_quant is enabled
         int32_t start_token_idx_sf = 0;
+
+        // optional when attention prior is used.
+        float* attention_prior_scores = nullptr;
+        int32_t const* attention_prior_focus = nullptr;
     };
 
     template <typename T, typename KVCacheBuffer>
@@ -323,6 +327,31 @@ public:
         return mCrossAttention;
     }
 
+    [[nodiscard]] bool ComputeAttentionPrior() const
+    {
+        return mComputeAttentionPrior;
+    }
+
+    [[nodiscard]] bool ApplyAttentionPrior() const
+    {
+        return mApplyAttentionPrior;
+    }
+
+    [[nodiscard]] int AttentionPriorLookahead() const
+    {
+        return mAttentionPriorLookahead;
+    }
+
+    [[nodiscard]] int AttentionPriorWindowLeft() const
+    {
+        return mAttentionPriorWindowLeft;
+    }
+
+    [[nodiscard]] int AttentionPriorWindowRight() const
+    {
+        return mAttentionPriorWindowRight;
+    }
+
     [[nodiscard]] bool useKVCache() const
     {
         return mUseKVCache;
@@ -409,6 +438,11 @@ public:
     int32_t mMaxContextLength = 0;
     bool mQKVBiasEnabled = false;
     bool mCrossAttention = false;
+    bool mComputeAttentionPrior = false;
+    bool mApplyAttentionPrior = false;
+    int mAttentionPriorLookahead = 5;
+    int mAttentionPriorWindowLeft = 1;
+    int mAttentionPriorWindowRight = 5;
     int mMaxDistance = 0;
     bool mPosShiftEnabled = false;
     bool mPagedContextFMHA = false;
@@ -469,14 +503,15 @@ public:
             mRotaryEmbeddingLongMscale, mRotaryEmbeddingMaxPositions, mRotaryEmbeddingOriginalMaxPositions,
             (int8_t) mPositionEmbeddingType, mUseLognScaling, mRemovePadding, (int32_t) mMaskType,
             mBlockSparseParams.data(), mPagedKVCache, mTokensPerBlock, mKVCacheQuantMode.value(), mTpSize, mTpRank,
-            mUnfuseQkvGemm, (int32_t) mType, mMaxContextLength, mQKVBiasEnabled, mCrossAttention, mMaxDistance,
-            mPosShiftEnabled, mPagedContextFMHA, mFP8ContextFMHA, mFP8AttenOutput, mFP8ContextMLA, mFP8GenerationMLA,
-            mChunkPrefillBufferBatchSize, mDenseContextFMHA, mHasFullAttentionMask, mIsSpecDecodingEnabled,
-            mUseSpecDecoding, mIsSpecDecTree, mSpecDecodingIsGenerationLengthVariable, mSpecDecodingMaxGenerationLength,
-            mIsMLAEnabled, mIsGenerationMLA, mUseGenFlashMLA, mMLAParams.data(), mCpSize, mCpRank, mCpGroup,
-            mNumAttnHeads, mNumAttnKVHeads, mNumKVHeadsOrigin, mAttnTpSize, mAttnTpRank, mAttnCpSize, mAttnCpRank,
-            mUlyssesMQABroadcast, mEnableContextFMHA, mFMHAForceFP32Acc, mMultiBlockMode, mEnableXQA, mUseKVCache,
-            mSkipAttn, mFuseFp4Quant, mNbMultiBlockSemaphores, mAttentionChunkSize.value_or(-1));
+            mUnfuseQkvGemm, (int32_t) mType, mMaxContextLength, mQKVBiasEnabled, mCrossAttention,
+            mComputeAttentionPrior, mApplyAttentionPrior, mMaxDistance, mPosShiftEnabled, mPagedContextFMHA,
+            mFP8ContextFMHA, mFP8AttenOutput, mFP8ContextMLA, mFP8GenerationMLA, mChunkPrefillBufferBatchSize,
+            mDenseContextFMHA, mHasFullAttentionMask, mIsSpecDecodingEnabled, mUseSpecDecoding, mIsSpecDecTree,
+            mSpecDecodingIsGenerationLengthVariable, mSpecDecodingMaxGenerationLength, mIsMLAEnabled, mIsGenerationMLA,
+            mUseGenFlashMLA, mMLAParams.data(), mCpSize, mCpRank, mCpGroup, mNumAttnHeads, mNumAttnKVHeads,
+            mNumKVHeadsOrigin, mAttnTpSize, mAttnTpRank, mAttnCpSize, mAttnCpRank, mUlyssesMQABroadcast,
+            mEnableContextFMHA, mFMHAForceFP32Acc, mMultiBlockMode, mEnableXQA, mUseKVCache, mSkipAttn, mFuseFp4Quant,
+            mNbMultiBlockSemaphores, mAttentionChunkSize.value_or(-1));
     };
 
 private:

--- a/cpp/tensorrt_llm/executor/request.cpp
+++ b/cpp/tensorrt_llm/executor/request.cpp
@@ -37,19 +37,20 @@ Request::Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming, 
     std::optional<LogitsPostProcessor> logitslogitsPostProcessor, std::optional<VecTokens> encoderInputTokenIds,
     std::optional<IdType> clientId, bool returnAllGeneratedTokens, float priority, RequestType type,
     std::optional<ContextPhaseParams> contextPhaseParams, std::optional<Tensor> encoderInputFeatures,
-    std::optional<SizeType32> encoderOutputLength, std::optional<Tensor> crossAttentionMask,
-    SizeType32 numReturnSequences, std::optional<EagleConfig> eagleConfig, std::optional<Tensor> skipCrossAttnBlocks,
-    std::optional<GuidedDecodingParams> guidedDecodingParams, std::optional<SizeType32> languageAdapterUid,
-    std::optional<MillisecondsType> allottedTimeMs, std::optional<CacheSaltIDType> cacheSaltID)
+    std::optional<SizeType32> encoderOutputLength, std::optional<Tensor> decoderContextFeatures,
+    std::optional<Tensor> crossAttentionMask, SizeType32 numReturnSequences, std::optional<EagleConfig> eagleConfig,
+    std::optional<Tensor> skipCrossAttnBlocks, std::optional<GuidedDecodingParams> guidedDecodingParams,
+    std::optional<SizeType32> languageAdapterUid, std::optional<MillisecondsType> allottedTimeMs,
+    std::optional<CacheSaltIDType> cacheSaltID, SizeType32 numVocabs)
     : mImpl(std::make_unique<Impl>(std::move(inputTokenIds), maxTokens, streaming, samplingConfig, outputConfig, endId,
         padId, std::move(positionIds), std::move(badWords), std::move(stopWords), std::move(embeddingBias),
         std::move(externalDraftTokensConfig), std::move(pTuningConfig), std::move(multimodalInput),
         std::move(multimodalEmbedding), std::move(mRopeConfig), std::move(loraConfig), lookaheadConfig,
         std::move(kvCacheRetentionConfig), std::move(logitsPostProcessorName), std::move(logitslogitsPostProcessor),
         std::move(encoderInputTokenIds), clientId, returnAllGeneratedTokens, priority, type,
-        std::move(contextPhaseParams), std::move(encoderInputFeatures), encoderOutputLength, crossAttentionMask,
-        numReturnSequences, eagleConfig, skipCrossAttnBlocks, std::move(guidedDecodingParams), languageAdapterUid,
-        allottedTimeMs, cacheSaltID))
+        std::move(contextPhaseParams), std::move(encoderInputFeatures), encoderOutputLength,
+        std::move(decoderContextFeatures), crossAttentionMask, numReturnSequences, eagleConfig, skipCrossAttnBlocks,
+        std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs, cacheSaltID, numVocabs))
 {
 }
 
@@ -183,6 +184,11 @@ std::optional<VecTokens> Request::getEncoderInputTokenIds() const
     return mImpl->getEncoderInputTokenIds();
 }
 
+std::optional<Tensor> Request::getDecoderContextFeatures() const
+{
+    return mImpl->getDecoderContextFeatures();
+}
+
 std::optional<IdType> Request::getClientId() const
 {
     return mImpl->getClientId();
@@ -251,6 +257,11 @@ std::optional<SizeType32> Request::getLanguageAdapterUid() const
 std::optional<CacheSaltIDType> Request::getCacheSaltID() const
 {
     return mImpl->getCacheSaltID();
+}
+
+SizeType32 Request::getNumVocabs() const
+{
+    return mImpl->getNumVocabs();
 }
 
 void Request::setStreaming(bool streaming)
@@ -388,6 +399,11 @@ void Request::setEncoderOutputLength(SizeType32 encoderOutputLength)
     mImpl->setEncoderOutputLength(encoderOutputLength);
 }
 
+void Request::setDecoderContextFeatures(Tensor decoderContextFeatures)
+{
+    return mImpl->setDecoderContextFeatures(decoderContextFeatures);
+}
+
 void Request::setCrossAttentionMask(Tensor crossAttentionMask)
 {
     mImpl->setCrossAttentionMask(crossAttentionMask);
@@ -421,5 +437,10 @@ void Request::setLanguageAdapterUid(SizeType32 languageAdapterUid)
 void Request::setCacheSaltID(CacheSaltIDType cacheSaltID)
 {
     return mImpl->setCacheSaltID(cacheSaltID);
+}
+
+void Request::setNumVocabs(SizeType32 numVocabs)
+{
+    return mImpl->setNumVocabs(numVocabs);
 }
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/requestImpl.h
+++ b/cpp/tensorrt_llm/executor/requestImpl.h
@@ -45,10 +45,11 @@ public:
         std::optional<VecTokens> encoderInputTokenIds, std::optional<IdType> clientId, bool returnAllGeneratedTokens,
         PriorityType priority, RequestType type, std::optional<ContextPhaseParams> contextPhaseParams,
         std::optional<Tensor> encoderInputFeatures, std::optional<SizeType32> encoderOutputLength,
-        std::optional<Tensor> crossAttentionMask, SizeType32 numReturnSequences, std::optional<EagleConfig> eagleConfig,
+        std::optional<Tensor> decoderContextFeatures, std::optional<Tensor> crossAttentionMask,
+        SizeType32 numReturnSequences, std::optional<EagleConfig> eagleConfig,
         std::optional<Tensor> skipCrossAttnBlocks, std::optional<GuidedDecodingParams> guidedDecodingParams,
         std::optional<SizeType32> languageAdapterUid, std::optional<MillisecondsType> allottedTimeMs,
-        std::optional<CacheSaltIDType> cacheSaltID)
+        std::optional<CacheSaltIDType> cacheSaltID, SizeType32 numVocabs = 1)
         : mInputTokenIds(std::move(inputTokenIds))
         , mMaxNewTokens(maxNewTokens)
         , mStreaming(streaming)
@@ -78,6 +79,7 @@ public:
         , mContextPhaseParams(std::move(contextPhaseParams))
         , mEncoderInputFeatures(std::move(encoderInputFeatures))
         , mEncoderOutputLength(encoderOutputLength)
+        , mDecoderContextFeatures(std::move(decoderContextFeatures))
         , mCrossAttentionMask(std::move(crossAttentionMask))
         , mNumReturnSequences(numReturnSequences)
         , mEagleConfig(std::move(eagleConfig))
@@ -86,6 +88,7 @@ public:
         , mLanguageAdapterUid(languageAdapterUid)
         , mAllottedTimeMs(allottedTimeMs)
         , mCacheSaltID(cacheSaltID)
+        , mNumVocabs(numVocabs)
     {
         validate();
     }
@@ -259,6 +262,11 @@ public:
         return mEncoderInputFeatures;
     }
 
+    [[nodiscard]] std::optional<Tensor> getDecoderContextFeatures() const
+    {
+        return mDecoderContextFeatures;
+    }
+
     [[nodiscard]] std::optional<Tensor> getCrossAttentionMask() const
     {
         return mCrossAttentionMask;
@@ -300,6 +308,11 @@ public:
     [[nodiscard]] std::optional<CacheSaltIDType> getCacheSaltID() const
     {
         return mCacheSaltID;
+    }
+
+    [[nodiscard]] SizeType32 getNumVocabs() const
+    {
+        return mNumVocabs;
     }
 
     void setStreaming(bool streaming)
@@ -432,6 +445,11 @@ public:
         mEncoderInputFeatures = encoderInputFeatures;
     }
 
+    void setDecoderContextFeatures(Tensor decoderContextFeatures)
+    {
+        mDecoderContextFeatures = decoderContextFeatures;
+    }
+
     void setCrossAttentionMask(Tensor crossAttentionMask)
     {
         mCrossAttentionMask = crossAttentionMask;
@@ -479,6 +497,11 @@ public:
     void setCacheSaltID(CacheSaltIDType cacheSaltID)
     {
         mCacheSaltID = cacheSaltID;
+    }
+
+    void setNumVocabs(SizeType32 numVocabs)
+    {
+        mNumVocabs = numVocabs;
     }
 
 private:
@@ -540,6 +563,7 @@ private:
         lambda(mKvCacheRetentionConfig);
         lambda(mLogitsPostProcessorName);
         lambda(mEncoderInputTokenIds);
+        lambda(mDecoderContextFeatures);
         lambda(mClientId);
         lambda(mReturnAllGeneratedTokens);
         lambda(mPriority);
@@ -555,6 +579,7 @@ private:
         lambda(mLanguageAdapterUid);
         lambda(mAllottedTimeMs ? std::make_optional(mAllottedTimeMs->count()) : std::nullopt);
         lambda(mCacheSaltID);
+        lambda(mNumVocabs);
     }
 
     VecTokens mInputTokenIds;
@@ -586,6 +611,7 @@ private:
     std::optional<ContextPhaseParams> mContextPhaseParams;
     std::optional<Tensor> mEncoderInputFeatures;
     std::optional<SizeType32> mEncoderOutputLength;
+    std::optional<Tensor> mDecoderContextFeatures;
     std::optional<Tensor> mCrossAttentionMask;
     SizeType32 mNumReturnSequences;
     std::optional<EagleConfig> mEagleConfig;
@@ -594,6 +620,7 @@ private:
     std::optional<SizeType32> mLanguageAdapterUid;
     std::optional<MillisecondsType> mAllottedTimeMs;
     std::optional<CacheSaltIDType> mCacheSaltID;
+    SizeType32 mNumVocabs;
 };
 
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/samplingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/samplingConfig.cpp
@@ -36,7 +36,7 @@ SamplingConfig::SamplingConfig(SizeType32 beamWidth, OptSize32 const& topK, OptF
     OptFloat const& beamSearchDiversityRate, OptFloat const& repetitionPenalty, OptFloat const& presencePenalty,
     OptFloat const& frequencyPenalty, OptFloat const& lengthPenalty, OptSize32 const& earlyStopping,
     OptSize32 const& noRepeatNgramSize, OptSize32 const& numReturnSequences, OptFloat const& minP,
-    OptVec<SizeType32> const& beamWidthArray)
+    OptVec<SizeType32> const& beamWidthArray, OptFloat const& cfgScale)
     : mBeamWidth(checkBeamWidth(beamWidth))
     , mTopK(checkTopK(topK))
     , mTopP(checkTopP(topP))
@@ -54,7 +54,8 @@ SamplingConfig::SamplingConfig(SizeType32 beamWidth, OptSize32 const& topK, OptF
     , mEarlyStopping(checkEarlyStopping(earlyStopping))
     , mNoRepeatNgramSize(checkNoRepeatNgramSize(noRepeatNgramSize))
     , mNumReturnSequences(checkNumReturnSequences(numReturnSequences, beamWidth))
-    , mMinP(checkMinP(minP))
+    , mMinP(checkMinP(minP)
+    , mCfgScale(checkCfgScale(cfgScale))
 {
     updateNumReturnBeams();
     std::tie(mBeamWidthArray, mBeamWidth) = checkBeamWidthArray(beamWidthArray, mBeamWidth);
@@ -69,7 +70,7 @@ bool SamplingConfig::operator==(SamplingConfig const& other) const
         && mPresencePenalty == other.mPresencePenalty && mFrequencyPenalty == other.mFrequencyPenalty
         && mLengthPenalty == other.mLengthPenalty && mEarlyStopping == other.mEarlyStopping
         && mNoRepeatNgramSize == other.mNoRepeatNgramSize && mNumReturnSequences == other.mNumReturnSequences
-        && mMinP == other.mMinP && mBeamWidthArray == other.mBeamWidthArray;
+        && mMinP == other.mMinP && mBeamWidthArray == other.mBeamWidthArray && mCfgScale == other.mCfgScale;
 }
 
 // Getters
@@ -161,6 +162,11 @@ OptSize32 SamplingConfig::getNoRepeatNgramSize() const
 OptSize32 SamplingConfig::getNumReturnSequences() const
 {
     return mNumReturnSequences;
+}
+
+OptFloat SamplingConfig::getCfgScale() const
+{
+    return mCfgScale;
 }
 
 std::optional<FloatType> SamplingConfig::getMinP() const
@@ -271,11 +277,22 @@ void SamplingConfig::setBeamWidthArray(OptVec<SizeType32> const& beamWidthArray)
     std::tie(mBeamWidthArray, mBeamWidth) = checkBeamWidthArray(beamWidthArray, mBeamWidth);
 }
 
+void SamplingConfig::setCfgScale(std::optional<FloatType> const& cfgScale)
+{
+    mCfgScale = checkCfgScale(cfgScale);
+}
+
 // Checkers
 SizeType32 SamplingConfig::checkBeamWidth(SizeType32 beamWidth)
 {
     TLLM_CHECK(beamWidth > 0 && beamWidth <= static_cast<SizeType32 const>(tensorrt_llm::kernels::kMaxBeamWidth));
     return beamWidth;
+}
+
+OptFloat const& SamplingConfig::checkCfgScale(OptFloat const& cfgScale)
+{
+    // TODO: implement checking the cfg scale
+    return cfgScale;
 }
 
 OptFloat const& SamplingConfig::checkTopK(OptFloat const& topK)

--- a/cpp/tensorrt_llm/executor/samplingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/samplingConfig.cpp
@@ -54,7 +54,7 @@ SamplingConfig::SamplingConfig(SizeType32 beamWidth, OptSize32 const& topK, OptF
     , mEarlyStopping(checkEarlyStopping(earlyStopping))
     , mNoRepeatNgramSize(checkNoRepeatNgramSize(noRepeatNgramSize))
     , mNumReturnSequences(checkNumReturnSequences(numReturnSequences, beamWidth))
-    , mMinP(checkMinP(minP)
+    , mMinP(checkMinP(minP))
     , mCfgScale(checkCfgScale(cfgScale))
 {
     updateNumReturnBeams();

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -705,6 +705,7 @@ Request Serialization::deserializeRequest(std::istream& is)
     auto contextPhaseParams = su::deserialize<std::optional<ContextPhaseParams>>(is);
     auto encoderInputFeatures = su::deserialize<std::optional<Tensor>>(is);
     auto encoderOutputLength = su::deserialize<std::optional<SizeType32>>(is);
+    auto decoderContextFeatures = su::deserialize<std::optional<Tensor>>(is);
     auto crossAttentionMask = su::deserialize<std::optional<Tensor>>(is);
     auto numReturnSequences = su::deserialize<SizeType32>(is);
     auto eagleConfig = su::deserialize<std::optional<EagleConfig>>(is);
@@ -724,8 +725,9 @@ Request Serialization::deserializeRequest(std::istream& is)
         std::move(kvCacheRetentionConfig), std::move(logitsPostProcessorName), std::nullopt,
         std::move(encoderInputTokenIds), clientId, returnAllGeneratedTokens, priority, requestType,
         std::move(contextPhaseParams), std::move(encoderInputFeatures), encoderOutputLength,
-        std::move(crossAttentionMask), numReturnSequences, std::move(eagleConfig), std::move(skipCrossAttnBlocks),
-        std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs, cacheSaltID);
+        std::move(decoderContextFeatures), std::move(crossAttentionMask), numReturnSequences, std::move(eagleConfig),
+        std::move(skipCrossAttnBlocks), std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs,
+        cacheSaltID);
 }
 
 void Serialization::serialize(Request const& request, std::ostream& os)

--- a/cpp/tensorrt_llm/kernels/cfgKernels.h
+++ b/cpp/tensorrt_llm/kernels/cfgKernels.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/runtime/iTensor.h"
+#include <cublas_v2.h>
+#include <cuda_fp16.h>
+
+namespace tensorrt_llm::kernels
+{
+
+//! Apply classifier-free guidance (CFG) on GPU in-place using cuBLAS.
+//! It overwrites `logitsView` with: logits = cfgScale * logits + (1 - cfgScale) * uncondLogits
+//! Only the slice [vocabOffset, vocabOffset + vocabSize) is modified.
+inline void invokeCfg(tensorrt_llm::runtime::CudaStream const& stream, runtime::ITensor::SharedPtr logitsView,
+    runtime::ITensor::SharedPtr uncondLogitsView, float cfgScale, runtime::SizeType32 vocabOffset,
+    runtime::SizeType32 vocabSize)
+{
+    using TensorPtr = runtime::ITensor::SharedPtr;
+
+    // Restrict to current vocabulary segment.
+    TensorPtr logitsVocabView = runtime::ITensor::slice(logitsView, {0, vocabOffset}, vocabSize);
+    TensorPtr uncondLogitsVocabView = runtime::ITensor::slice(uncondLogitsView, {0, vocabOffset}, vocabSize);
+
+    void* condPtr = logitsVocabView->data();
+    void const* uncondPtr = uncondLogitsVocabView->data();
+
+    cudaDataType_t dataType{};
+    switch (logitsVocabView->getDataType())
+    {
+    case nvinfer1::DataType::kFLOAT: dataType = CUDA_R_32F; break;
+    case nvinfer1::DataType::kHALF: dataType = CUDA_R_16F; break;
+    default: TLLM_THROW("Unsupported data type for CFG");
+    }
+
+    auto handlePtr = getCublasHandle();
+    auto& handle = *handlePtr;
+    tensorrt_llm::common::check_cuda_error(cublasSetStream(handle, stream.get()));
+
+    int n = static_cast<int>(vocabSize);
+    int inc = 1;
+
+    // Use float for the scaling factors and always accumulate in FP32 to
+    // satisfy cuBLAS requirements (FP16 vectors must use FP32 compute/alpha).
+    float alphaF = cfgScale;                                                            // Scaling factor in FP32
+    float axpyF = 1.0f - cfgScale;                                                      // (1 - cfgScale) in FP32
+
+    tensorrt_llm::common::check_cuda_error(cublasScalEx(handle, n, &alphaF, CUDA_R_32F, // alpha
+        condPtr, dataType,                                                              // x and its type
+        inc, CUDA_R_32F));                                                              // increments + compute type
+
+    tensorrt_llm::common::check_cuda_error(cublasAxpyEx(handle, n, &axpyF, CUDA_R_32F,  // alpha
+        uncondPtr, dataType, inc,                                                       // x
+        condPtr, dataType, inc,                                                         // y
+        CUDA_R_32F));                                                                   // compute type
+}
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.cpp
+++ b/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.cpp
@@ -84,7 +84,7 @@ FusedMHARunnerV2::FusedMHARunnerV2(MHARunnerFixedParams fixedParams)
     : mFixedParams(fixedParams)
 {
     TLLM_CHECK_WITH_INFO((mSM == kSM_80 || mSM == kSM_86 || mSM == kSM_89 || mSM == kSM_90 || mSM == kSM_100
-                             || mSM == kSM_103 || mSM == kSM_120 || mSM == kSM_121),
+                             || mSM == kSM_103 || mSM == kSM_110 || mSM == kSM_120 || mSM == kSM_121),
         "Unsupported architecture");
     TLLM_CHECK_WITH_INFO((mFixedParams.dataType == DATA_TYPE_FP16 || mFixedParams.dataType == DATA_TYPE_BF16
                              || mFixedParams.dataType == DATA_TYPE_E4M3),
@@ -348,7 +348,7 @@ void FusedMHARunnerV2::setupLaunchParams(MHARunnerParams runnerParams)
     bool const isSm80 = (mSM == kSM_80);
     bool const isSm89 = (mSM == kSM_89);
     bool const isSm100f = (mSM == kSM_100 || mSM == kSM_103);
-    bool const isSm120f = (mSM == kSM_120 || mSM == kSM_121);
+    bool const isSm120f = (mSM == kSM_110 || mSM == kSM_120 || mSM == kSM_121);
 
     // Sliding_or_chunked_causal mask.
     if ((runnerParams.kvSeqLen > runnerParams.slidingWindowSize

--- a/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.cpp
+++ b/cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.cpp
@@ -84,7 +84,7 @@ FusedMHARunnerV2::FusedMHARunnerV2(MHARunnerFixedParams fixedParams)
     : mFixedParams(fixedParams)
 {
     TLLM_CHECK_WITH_INFO((mSM == kSM_80 || mSM == kSM_86 || mSM == kSM_89 || mSM == kSM_90 || mSM == kSM_100
-                             || mSM == kSM_103 || mSM == kSM_110 || mSM == kSM_120 || mSM == kSM_121),
+                             || mSM == kSM_103 || mSM == kSM_120 || mSM == kSM_121),
         "Unsupported architecture");
     TLLM_CHECK_WITH_INFO((mFixedParams.dataType == DATA_TYPE_FP16 || mFixedParams.dataType == DATA_TYPE_BF16
                              || mFixedParams.dataType == DATA_TYPE_E4M3),
@@ -348,7 +348,7 @@ void FusedMHARunnerV2::setupLaunchParams(MHARunnerParams runnerParams)
     bool const isSm80 = (mSM == kSM_80);
     bool const isSm89 = (mSM == kSM_89);
     bool const isSm100f = (mSM == kSM_100 || mSM == kSM_103);
-    bool const isSm120f = (mSM == kSM_110 || mSM == kSM_120 || mSM == kSM_121);
+    bool const isSm120f = (mSM == kSM_120 || mSM == kSM_121);
 
     // Sliding_or_chunked_causal mask.
     if ((runnerParams.kvSeqLen > runnerParams.slidingWindowSize

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention.h
@@ -210,6 +210,16 @@ struct Multihead_attention_params_base
 
     int const* memory_length_per_sample = nullptr;
     int32_t const* mrope_position_deltas = nullptr;
+
+    // fields related to attention prior:
+    // scores which accumulate window of cross attention probs
+    // and focus which specifies which index in encoder output sequence
+    float* attention_prior_scores = nullptr;
+    int const* attention_prior_focus = nullptr;
+    bool apply_attention_prior = false;
+    int attention_prior_lookahead = 5;
+    int attention_prior_window_left = 1;
+    int attention_prior_window_right = 5;
 };
 
 template <typename T, bool USE_CROSS_ATTENTION = false>

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -488,7 +488,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
                  std::vector<SizeType32> const&, std::optional<tbk::TempAttentionWindowInputs> const&,
                  nvinfer1::DataType, SizeType32, int64_t, runtime::SizeType32, bool, bool, tbk::CacheType,
                  std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
-                 bool, bool, std::shared_ptr<tbc::KvCacheConnectorManager>>(),
+                 bool, bool, SizeType32, std::shared_ptr<tbc::KvCacheConnectorManager>>(),
             nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
             nb::arg("blocks_per_window"), nb::arg("max_num_sequences"), nb::arg("max_beam_width"),
             nb::arg("max_attention_window_vec"), nb::arg("temp_attention_window_inputs").none(), nb::arg("dtype"),
@@ -496,8 +496,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("enable_block_reuse") = false, nb::arg("onboard_blocks") = true,
             nb::arg("cache_type") = tbk::CacheType::kSELF, nb::arg("secondary_offload_min_priority") = std::nullopt,
             nb::arg("event_manager") = nullptr, nb::arg("enable_partial_reuse") = true,
-            nb::arg("copy_on_partial_reuse") = true, nb::arg("kv_connector_manager") = nullptr,
-            nb::call_guard<nb::gil_scoped_release>());
+            nb::arg("copy_on_partial_reuse") = true, nb::arg("num_vocabs") = 1,
+            nb::arg("kv_connector_manager") = nullptr, nb::call_guard<nb::gil_scoped_release>());
 }
 
 void tb::BasePeftCacheManagerBindings::initBindings(nb::module_& m)

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -115,6 +115,7 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mPriority,                                                 //
         from_torch(mEncoderInputFeatures),                         //
         mEncoderOutputLength,                                      //
+        from_torch(mDecoderContextFeatures),                       //
         from_torch(mCrossAttentionMask),                           //
         getLlmRequestType(),                                       //
         std::nullopt,                                              // inputTokenExtraIds

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
@@ -76,6 +76,7 @@ public:
         executor::PriorityType priority = executor::Request::kDefaultPriority,
         std::optional<TensorPtr> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<TensorPtr> decoderContextFeatures = std::nullopt,
         std::optional<TensorPtr> crossAttentionMask = std::nullopt,
         tb::LlmRequestType llmRequestType = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         std::optional<VecTokenExtraIds> inputTokenExtraIds = std::nullopt, SizeType32 numReturnSequences = 1,
@@ -135,6 +136,7 @@ public:
             priority,                                                                                            //
             encoderInputFeatures,                                                                                //
             encoderOutputLength,                                                                                 //
+            decoderContextFeatures,                                                                              //
             crossAttentionMask,                                                                                  //
             llmRequestType,                                                                                      //
             inputTokenExtraIds                                                                                   //

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -81,7 +81,7 @@ void initRequestBindings(nb::module_& m)
     };
     auto samplingConfigSetstate = [](tle::SamplingConfig& samplingConfig, nb::tuple const& state)
     {
-        if (state.size() != 19)
+        if (state.size() != 20)
         {
             throw std::runtime_error("Invalid SamplingConfig state!");
         }
@@ -103,29 +103,31 @@ void initRequestBindings(nb::module_& m)
             nb::cast<std::optional<SizeType32>>(state[15]),                       // NoRepeatNgramSize
             nb::cast<std::optional<SizeType32>>(state[16]),                       // NumReturnSequences
             nb::cast<std::optional<FloatType>>(state[17]),                        // MinP
-            nb::cast<std::optional<std::vector<SizeType32>>>(state[18])           // BeamWidthArray
+            nb::cast<std::optional<std::vector<SizeType32>>>(state[18]),          // BeamWidthArray
+            nb::cast<std::optional<FloatType>>(state[19])                         // CfgScale
         );
     };
     nb::class_<tle::SamplingConfig>(m, "SamplingConfig")
         .def(nb::init<tle::SizeType32,
-                 std::optional<tle::SizeType32> const&,             // beamWidth
-                 std::optional<tle::FloatType> const&,              // topP
-                 std::optional<tle::FloatType> const&,              // topPMin
-                 std::optional<tle::TokenIdType> const&,            // topPResetIds
-                 std::optional<tle::FloatType> const&,              // topPDecay
-                 std::optional<tle::RandomSeedType> const&,         // seed
-                 std::optional<tle::FloatType> const&,              // temperature
-                 std::optional<tle::SizeType32> const&,             // minTokens
-                 std::optional<tle::FloatType> const&,              // beamSearchDiversityRate
-                 std::optional<tle::FloatType> const&,              // repetitionPenalty
-                 std::optional<tle::FloatType> const&,              // presencePenalty
-                 std::optional<tle::FloatType> const&,              // frequencyPenalty
-                 std::optional<tle::FloatType> const&,              // lengthPenalty
-                 std::optional<tle::SizeType32> const&,             // earlyStopping
-                 std::optional<tle::SizeType32> const&,             // noRepeatNgramSize
-                 std::optional<tle::SizeType32> const&,             // numReturnSequences
-                 std::optional<tle::FloatType> const&,              // minP
-                 std::optional<std::vector<tle::SizeType32>> const& // beamWidthArray
+                 std::optional<tle::SizeType32> const&,              // beamWidth
+                 std::optional<tle::FloatType> const&,               // topP
+                 std::optional<tle::FloatType> const&,               // topPMin
+                 std::optional<tle::TokenIdType> const&,             // topPResetIds
+                 std::optional<tle::FloatType> const&,               // topPDecay
+                 std::optional<tle::RandomSeedType> const&,          // seed
+                 std::optional<tle::FloatType> const&,               // temperature
+                 std::optional<tle::SizeType32> const&,              // minTokens
+                 std::optional<tle::FloatType> const&,               // beamSearchDiversityRate
+                 std::optional<tle::FloatType> const&,               // repetitionPenalty
+                 std::optional<tle::FloatType> const&,               // presencePenalty
+                 std::optional<tle::FloatType> const&,               // frequencyPenalty
+                 std::optional<tle::FloatType> const&,               // lengthPenalty
+                 std::optional<tle::SizeType32> const&,              // earlyStopping
+                 std::optional<tle::SizeType32> const&,              // noRepeatNgramSize
+                 std::optional<tle::SizeType32> const&,              // numReturnSequences
+                 std::optional<tle::FloatType> const&,               // minP
+                 std::optional<std::vector<tle::SizeType32>> const&, // beamWidthArray
+                 std::optional<tle::FloatType> const&                // CfgScale
                  >(),
             // clang-format off
             nb::arg("beam_width") = 1,
@@ -147,7 +149,8 @@ void initRequestBindings(nb::module_& m)
             nb::arg("no_repeat_ngram_size") = nb::none(),
             nb::arg("num_return_sequences") = nb::none(),
             nb::arg("min_p") = nb::none(),
-            nb::arg("beam_width_array") = nb::none())               // clang-format on
+            nb::arg("beam_width_array") = nb::none(),
+            nb::arg("cfg_scale") = nb::none())                       // clang-format on
         .def_prop_rw("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
         .def_prop_rw("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
         .def_prop_rw("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
@@ -174,6 +177,7 @@ void initRequestBindings(nb::module_& m)
         .def_prop_rw("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
         .def_prop_rw(
             "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
+        .def_prop_rw("cfg_scale", &tle::SamplingConfig::getCfgScale, &tle::SamplingConfig::setCfgScale)
         .def("__getstate__", samplingConfigGetstate)
         .def("__setstate__", samplingConfigSetstate);
 
@@ -572,8 +576,8 @@ void initRequestBindings(nb::module_& m)
             self.getLogitsPostProcessorName(), self.getLogitsPostProcessor(), self.getEncoderInputTokenIds(),
             self.getClientId(), self.getReturnAllGeneratedTokens(), self.getPriority(), self.getRequestType(),
             self.getContextPhaseParams(), self.getEncoderInputFeatures(), self.getEncoderOutputLength(),
-            self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
-            self.getGuidedDecodingParams(), self.getCacheSaltID());
+            self.getDecoderContextFeatures(), self.getCrossAttentionMask(), self.getEagleConfig(),
+            self.getSkipCrossAttnBlocks(), self.getGuidedDecodingParams(), self.getCacheSaltID(), self.getNumVocabs());
     };
     auto requestSetstate = [](tle::Request& self, nb::tuple const& state)
     {
@@ -602,7 +606,7 @@ void initRequestBindings(nb::module_& m)
             nb::cast<std::optional<tle::Tensor>>(state[29]), nb::cast<std::optional<tle::Tensor>>(state[30]), 1,
             nb::cast<std::optional<tle::EagleConfig>>(state[31]), nb::cast<std::optional<tle::Tensor>>(state[32]),
             nb::cast<std::optional<tle::GuidedDecodingParams>>(state[33]),
-            nb::cast<std::optional<SizeType32>>(state[34]),            // languageAdapterUid
+            nb::cast<std::optional<tle::SizeType32>>(state[34]),       // languageAdapterUid
             nb::cast<std::optional<tle::MillisecondsType>>(state[35]), // allottedTimeMs
             nb::cast<std::optional<tle::CacheSaltIDType>>(state[36]),  // cacheSaltID
             nb::cast<SizeType32>(state[37]));                          // numVocabs

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -577,7 +577,7 @@ void initRequestBindings(nb::module_& m)
     };
     auto requestSetstate = [](tle::Request& self, nb::tuple const& state)
     {
-        if (state.size() != 34)
+        if (state.size() != 38)
         {
             throw std::runtime_error("Invalid Request state!");
         }
@@ -599,10 +599,13 @@ void initRequestBindings(nb::module_& m)
             nb::cast<tle::PriorityType>(state[24]), nb::cast<tle::RequestType>(state[25]),
             nb::cast<std::optional<tle::ContextPhaseParams>>(state[26]),
             nb::cast<std::optional<tle::Tensor>>(state[27]), nb::cast<std::optional<SizeType32>>(state[28]),
-            nb::cast<std::optional<tle::Tensor>>(state[29]), 1, nb::cast<std::optional<tle::EagleConfig>>(state[30]),
-            nb::cast<std::optional<tle::Tensor>>(state[31]),
-            nb::cast<std::optional<tle::GuidedDecodingParams>>(state[32]),
-            nb::cast<std::optional<tle::CacheSaltIDType>>(state[33]));
+            nb::cast<std::optional<tle::Tensor>>(state[29]), nb::cast<std::optional<tle::Tensor>>(state[30]), 1,
+            nb::cast<std::optional<tle::EagleConfig>>(state[31]), nb::cast<std::optional<tle::Tensor>>(state[32]),
+            nb::cast<std::optional<tle::GuidedDecodingParams>>(state[33]),
+            nb::cast<std::optional<SizeType32>>(state[34]),            // languageAdapterUid
+            nb::cast<std::optional<tle::MillisecondsType>>(state[35]), // allottedTimeMs
+            nb::cast<std::optional<tle::CacheSaltIDType>>(state[36]),  // cacheSaltID
+            nb::cast<SizeType32>(state[37]));                          // numVocabs
     };
 
     nb::class_<tle::Request> request(m, "Request", nb::dynamic_attr());
@@ -636,6 +639,7 @@ void initRequestBindings(nb::module_& m)
                  std::optional<tle::ContextPhaseParams>,        // contextPhaseParams
                  std::optional<tle::Tensor>,                    // encoderInputFeatures
                  std::optional<tle::SizeType32>,                // encoderOutputLength
+                 std::optional<tle::Tensor>,                    // decoderContextFeatures
                  std::optional<tle::Tensor>,                    // crossAttentionMask
                  SizeType32,                                    // numReturnSequences
                  std::optional<tle::EagleConfig>,               // eagleConfig
@@ -643,7 +647,8 @@ void initRequestBindings(nb::module_& m)
                  std::optional<tle::GuidedDecodingParams>,      // guidedDecodingParams
                  std::optional<tle::SizeType32>,                // languageAdapterUid
                  std::optional<tle::MillisecondsType>,          // allottedTimeMs
-                 std::optional<tle::CacheSaltIDType>            // cacheSaltID
+                 std::optional<tle::CacheSaltIDType>,           // cacheSaltID
+                 SizeType32                                     // numVocabs
                  >(),
             // clang-format off
         nb::arg("input_token_ids"),
@@ -676,6 +681,7 @@ void initRequestBindings(nb::module_& m)
         nb::arg("context_phase_params") = nb::none(),
         nb::arg("encoder_input_features") = nb::none(),
         nb::arg("encoder_output_length") = nb::none(),
+        nb::arg("decoder_context_features") = nb::none(),
         nb::arg("cross_attention_mask") = nb::none(),
         nb::arg("num_return_sequences") = 1,
         nb::arg("eagle_config") = nb::none(),
@@ -683,8 +689,9 @@ void initRequestBindings(nb::module_& m)
         nb::arg("guided_decoding_params") = nb::none(),
         nb::arg("language_adapter_uid") = nb::none(),
         nb::arg("allotted_time_ms") = nb::none(),
-        nb::arg("cache_salt_id") = nb::none()
-    )             // clang-format on
+        nb::arg("cache_salt_id") = nb::none(),
+        nb::arg("num_vocabs") = 1
+    )                         // clang-format on
         .def_prop_ro("input_token_ids", &tle::Request::getInputTokenIds)
         .def_prop_ro("max_tokens", &tle::Request::getMaxTokens)
         .def_prop_rw("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)
@@ -719,6 +726,8 @@ void initRequestBindings(nb::module_& m)
         .def_prop_rw("request_type", &tle::Request::getRequestType, &tle::Request::setRequestType)
         .def_prop_rw(
             "encoder_input_features", &tle::Request::getEncoderInputFeatures, &tle::Request::setEncoderInputFeatures)
+        .def_prop_rw("decoder_context_features", &tle::Request::getDecoderContextFeatures,
+            &tle::Request::setDecoderContextFeatures)
         .def_prop_rw("cross_attention_mask", &tle::Request::getCrossAttentionMask, &tle::Request::setCrossAttentionMask)
         .def_prop_rw("eagle_config", &tle::Request::getEagleConfig, &tle::Request::setEagleConfig)
         .def_prop_rw(
@@ -727,6 +736,7 @@ void initRequestBindings(nb::module_& m)
             "guided_decoding_params", &tle::Request::getGuidedDecodingParams, &tle::Request::setGuidedDecodingParams)
         .def_prop_rw("allotted_time_ms", &tle::Request::getAllottedTimeMs, &tle::Request::setAllottedTimeMs)
         .def_prop_rw("cache_salt_id", &tle::Request::getCacheSaltID, &tle::Request::setCacheSaltID)
+        .def_prop_rw("num_vocabs", &tle::Request::getNumVocabs, &tle::Request::setNumVocabs)
         .def_prop_rw("context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
         .def("__getstate__", requestGetstate)
         .def("__setstate__", requestSetstate);

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
@@ -294,7 +294,7 @@ void initBindings(nb::module_& m)
             nb::call_guard<nb::gil_scoped_release>())
         .def("setup", &tr::GptDecoderBatched::setup, nb::arg("mode"), nb::arg("max_num_sequences"),
             nb::arg("max_beam_width"), nb::arg("dtype"), nb::arg("model_config"), nb::arg("world_config"),
-            nb::call_guard<nb::gil_scoped_release>())
+            nb::arg("vocab_size") = 0, nb::call_guard<nb::gil_scoped_release>())
         .def("forward_async", &tr::GptDecoderBatched::forwardAsync, nb::arg("decoder_state"), nb::arg("input"),
             nb::call_guard<nb::gil_scoped_release>())
         .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, nb::rv_policy::reference)

--- a/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.cpp
@@ -40,12 +40,13 @@ GPTAttentionPluginCommon::GPTAttentionPluginCommon(int layer_idx, int num_heads,
     tensorrt_llm::kernels::ContextFMHAType context_fmha_type, int kv_cache_quant_mode, bool remove_input_padding,
     tensorrt_llm::kernels::AttentionMaskType mask_type, tensorrt_llm::kernels::BlockSparseParams block_sparse_params,
     bool paged_kv_cache, int tokens_per_block, nvinfer1::DataType type, int32_t max_context_length,
-    bool qkv_bias_enabled, bool cross_attention, int max_distance, bool pos_shift_enabled, bool dense_context_fmha,
-    bool use_paged_context_fmha, bool use_fp8_context_fmha, bool has_full_attention_mask, bool use_cache,
-    bool is_spec_decoding_enabled, bool spec_decoding_is_generation_length_variable,
-    int32_t spec_decoding_max_generation_length, bool is_mla_enabled, int q_lora_rank, int kv_lora_rank,
-    int qk_nope_head_dim, int qk_rope_head_dim, int v_head_dim, bool fuse_fp4_quant, bool skip_attn, int cp_size,
-    int cp_rank, std::set<int32_t> cp_group)
+    bool qkv_bias_enabled, bool cross_attention, bool compute_attention_prior, bool apply_attention_prior,
+    int attention_prior_lookahead, int attention_prior_window_left, int attention_prior_window_right, int max_distance,
+    bool pos_shift_enabled, bool dense_context_fmha, bool use_paged_context_fmha, bool use_fp8_context_fmha,
+    bool has_full_attention_mask, bool use_cache, bool is_spec_decoding_enabled,
+    bool spec_decoding_is_generation_length_variable, int32_t spec_decoding_max_generation_length, bool is_mla_enabled,
+    int q_lora_rank, int kv_lora_rank, int qk_nope_head_dim, int qk_rope_head_dim, int v_head_dim, bool fuse_fp4_quant,
+    bool skip_attn, int cp_size, int cp_rank, std::set<int32_t> cp_group)
     : mResource{DecoderXQARunner::getResourceGlobal()}
 {
     mLayerIdx = layer_idx;
@@ -85,6 +86,11 @@ GPTAttentionPluginCommon::GPTAttentionPluginCommon(int layer_idx, int num_heads,
     mMaxContextLength = max_context_length;
     mQKVBiasEnabled = qkv_bias_enabled;
     mCrossAttention = cross_attention;
+    mComputeAttentionPrior = compute_attention_prior;
+    mApplyAttentionPrior = apply_attention_prior;
+    mAttentionPriorLookahead = attention_prior_lookahead;
+    mAttentionPriorWindowLeft = attention_prior_window_left;
+    mAttentionPriorWindowRight = attention_prior_window_right;
     mMaxDistance = max_distance;
     mPosShiftEnabled = pos_shift_enabled;
     mDenseContextFMHA = dense_context_fmha;
@@ -149,6 +155,11 @@ GPTAttentionPluginCommon::GPTAttentionPluginCommon(void const* data, size_t leng
     read(d, mMaxContextLength);
     read(d, mQKVBiasEnabled);
     read(d, mCrossAttention);
+    read(d, mComputeAttentionPrior);
+    read(d, mApplyAttentionPrior);
+    read(d, mAttentionPriorLookahead);
+    read(d, mAttentionPriorWindowLeft);
+    read(d, mAttentionPriorWindowRight);
     read(d, mMaxDistance);
     read(d, mPosShiftEnabled);
     read(d, mDenseContextFMHA);
@@ -214,13 +225,14 @@ size_t GPTAttentionPluginCommon::getCommonSerializationSize() const noexcept
         + sizeof(mEnableXQA) + sizeof(unsigned int) // mKVCacheQuantMode
         + sizeof(mRemovePadding) + sizeof(mMaskType) + sizeof(mBlockSparseParams) + sizeof(mPagedKVCache)
         + sizeof(mTokensPerBlock) + sizeof(mType) + sizeof(mMaxContextLength) + sizeof(mQKVBiasEnabled)
-        + sizeof(mCrossAttention) + sizeof(mMaxDistance) + sizeof(mPosShiftEnabled) + sizeof(mDenseContextFMHA)
-        + sizeof(mPagedContextFMHA) + sizeof(mFP8ContextFMHA) + sizeof(mFP8AttenOutput) + sizeof(mHasFullAttentionMask)
-        + sizeof(mUseKVCache) + sizeof(mUnfuseQkvGemm) + sizeof(mUseLognScaling) + sizeof(mIsSpecDecodingEnabled)
-        + sizeof(mUseSpecDecoding) + sizeof(mSpecDecodingIsGenerationLengthVariable)
-        + sizeof(mSpecDecodingMaxGenerationLength) + sizeof(mNbMultiBlockSemaphores) + sizeof(mIsMLAEnabled)
-        + sizeof(mMLAParams) + sizeof(mFuseFp4Quant) + sizeof(mSkipAttn)
-        + sizeof(uint32_t) // size of DecoderXQARunnerResource buffer.
+        + sizeof(mCrossAttention) + sizeof(mComputeAttentionPrior) + sizeof(mApplyAttentionPrior)
+        + sizeof(mAttentionPriorLookahead) + sizeof(mAttentionPriorWindowLeft) + sizeof(mAttentionPriorWindowRight)
+        + sizeof(mMaxDistance) + sizeof(mPosShiftEnabled) + sizeof(mDenseContextFMHA) + sizeof(mPagedContextFMHA)
+        + sizeof(mFP8ContextFMHA) + sizeof(mFP8AttenOutput) + sizeof(mHasFullAttentionMask) + sizeof(mUseKVCache)
+        + sizeof(mUnfuseQkvGemm) + sizeof(mUseLognScaling) + sizeof(mIsSpecDecodingEnabled) + sizeof(mUseSpecDecoding)
+        + sizeof(mSpecDecodingIsGenerationLengthVariable) + sizeof(mSpecDecodingMaxGenerationLength)
+        + sizeof(mNbMultiBlockSemaphores) + sizeof(mIsMLAEnabled) + sizeof(mMLAParams) + sizeof(mFuseFp4Quant)
+        + sizeof(mSkipAttn) + sizeof(uint32_t) // size of DecoderXQARunnerResource buffer.
         + sizeof(mCpSize) + sizeof(mCpRank) + sizeof(int32_t) * mCpGroup.size() + mResource->getSerializationSize();
 }
 
@@ -264,6 +276,11 @@ void GPTAttentionPluginCommon::serializeCommon(void* buffer) const noexcept
     write(d, mMaxContextLength);
     write(d, mQKVBiasEnabled);
     write(d, mCrossAttention);
+    write(d, mComputeAttentionPrior);
+    write(d, mApplyAttentionPrior);
+    write(d, mAttentionPriorLookahead);
+    write(d, mAttentionPriorWindowLeft);
+    write(d, mAttentionPriorWindowRight);
     write(d, mMaxDistance);
     write(d, mPosShiftEnabled);
     write(d, mDenseContextFMHA);
@@ -347,6 +364,11 @@ GPTAttentionPluginCreatorCommon::GPTAttentionPluginCreatorCommon()
     mPluginAttributes.emplace_back(PluginField("max_context_length", nullptr, PluginFieldType::kINT32));
     mPluginAttributes.emplace_back(PluginField("qkv_bias_enabled", nullptr, PluginFieldType::kINT8));
     mPluginAttributes.emplace_back(PluginField("do_cross_attention", nullptr, PluginFieldType::kINT8));
+    mPluginAttributes.emplace_back(PluginField("compute_attention_prior", nullptr, PluginFieldType::kINT8));
+    mPluginAttributes.emplace_back(PluginField("apply_attention_prior", nullptr, PluginFieldType::kINT8));
+    mPluginAttributes.emplace_back(PluginField("attention_prior_lookahead", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("attention_prior_window_left", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("attention_prior_window_right", nullptr, PluginFieldType::kINT32));
     mPluginAttributes.emplace_back(PluginField("max_distance", nullptr, PluginFieldType::kINT32));
     mPluginAttributes.emplace_back(PluginField("pos_shift_enabled", nullptr, PluginFieldType::kINT8));
     mPluginAttributes.emplace_back(PluginField("dense_context_fmha", nullptr, PluginFieldType::kINT8));

--- a/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.h
+++ b/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.h
@@ -53,13 +53,15 @@ public:
         tensorrt_llm::kernels::AttentionMaskType mask_type,
         tensorrt_llm::kernels::BlockSparseParams block_sparse_params, bool paged_kv_cache, int tokens_per_block,
         nvinfer1::DataType type, int32_t max_context_length, bool qkv_bias_enabled, bool cross_attention = false,
-        int max_distance = 0, bool pos_shift_enabled = false, bool dense_context_fmha = false,
-        bool use_paged_context_fmha = true, bool use_fp8_context_fmha = true, bool has_full_attention_mask = false,
-        bool use_cache = true, bool is_spec_decoding_enabled = false,
-        bool spec_decoding_is_generation_length_variable = false, int32_t spec_decoding_max_generation_length = 1,
-        bool is_mla_enabled = false, int q_lora_rank = 0, int kv_lora_rank = 0, int qk_nope_head_dim = 0,
-        int qk_rope_head_dim = 0, int v_head_dim = 0, bool fuse_fp4_quant = false, bool skip_attn = false,
-        int cp_size = 1, int cp_rank = 0, std::set<int32_t> cp_group = {});
+        bool compute_attention_prior = false, bool apply_attention_prior = false, int attention_prior_lookahead = 5,
+        int attention_prior_window_left = 1, int attention_prior_window_right = 5, int max_distance = 0,
+        bool pos_shift_enabled = false, bool dense_context_fmha = false, bool use_paged_context_fmha = true,
+        bool use_fp8_context_fmha = true, bool has_full_attention_mask = false, bool use_cache = true,
+        bool is_spec_decoding_enabled = false, bool spec_decoding_is_generation_length_variable = false,
+        int32_t spec_decoding_max_generation_length = 1, bool is_mla_enabled = false, int q_lora_rank = 0,
+        int kv_lora_rank = 0, int qk_nope_head_dim = 0, int qk_rope_head_dim = 0, int v_head_dim = 0,
+        bool fuse_fp4_quant = false, bool skip_attn = false, int cp_size = 1, int cp_rank = 0,
+        std::set<int32_t> cp_group = {});
 
     GPTAttentionPluginCommon(void const* data, size_t length);
 

--- a/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
@@ -59,23 +59,25 @@ GPTAttentionPlugin::GPTAttentionPlugin(int layer_idx, int num_heads, int vision_
     tensorrt_llm::kernels::ContextFMHAType context_fmha_type, int kv_cache_quant_mode, bool remove_input_padding,
     tensorrt_llm::kernels::AttentionMaskType mask_type, tensorrt_llm::kernels::BlockSparseParams block_sparse_params,
     bool paged_kv_cache, int tokens_per_block, nvinfer1::DataType type, int32_t max_context_length,
-    bool qkv_bias_enabled, bool cross_attention, int max_distance, bool pos_shift_enabled, bool dense_context_fmha,
-    bool use_paged_context_fmha, bool use_fp8_context_fmha, bool has_full_attention_mask, bool use_cache,
-    bool is_spec_decoding_enabled, bool spec_decoding_is_generation_length_variable,
-    int spec_decoding_max_generation_length, bool is_mla_enabled, int q_lora_rank, int kv_lora_rank,
-    int qk_nope_head_dim, int qk_rope_head_dim, int v_head_dim, bool fuse_fp4_quant, bool skip_attn, int cp_size,
-    int cp_rank, std::set<int32_t> cp_group)
+    bool qkv_bias_enabled, bool cross_attention, bool compute_attention_prior, bool apply_attention_prior,
+    int attention_prior_lookahead, int attention_prior_window_left, int attention_prior_window_right, int max_distance,
+    bool pos_shift_enabled, bool dense_context_fmha, bool use_paged_context_fmha, bool use_fp8_context_fmha,
+    bool has_full_attention_mask, bool use_cache, bool is_spec_decoding_enabled,
+    bool spec_decoding_is_generation_length_variable, int spec_decoding_max_generation_length, bool is_mla_enabled,
+    int q_lora_rank, int kv_lora_rank, int qk_nope_head_dim, int qk_rope_head_dim, int v_head_dim, bool fuse_fp4_quant,
+    bool skip_attn, int cp_size, int cp_rank, std::set<int32_t> cp_group)
     : GPTAttentionPluginCommon(layer_idx, num_heads, vision_start, vision_length, num_kv_heads, num_kv_heads_origin,
         head_size, unidirectional, q_scaling, attn_logit_softcapping_scale, position_embedding_type,
         rotary_embedding_dim, rotary_embedding_base, rotary_embedding_scale_type, rotary_embedding_scale,
         rotary_embedding_short_m_scale, rotary_embedding_long_m_scale, rotary_embedding_max_positions,
         rotary_embedding_original_max_positions, tp_size, tp_rank, unfuse_qkv_gemm, use_logn_scaling, context_fmha_type,
         kv_cache_quant_mode, remove_input_padding, mask_type, block_sparse_params, paged_kv_cache, tokens_per_block,
-        type, max_context_length, qkv_bias_enabled, cross_attention, max_distance, pos_shift_enabled,
-        dense_context_fmha, use_paged_context_fmha, use_fp8_context_fmha, has_full_attention_mask, use_cache,
-        is_spec_decoding_enabled, spec_decoding_is_generation_length_variable, spec_decoding_max_generation_length,
-        is_mla_enabled, q_lora_rank, kv_lora_rank, qk_nope_head_dim, qk_rope_head_dim, v_head_dim, fuse_fp4_quant,
-        skip_attn, cp_size, cp_rank, cp_group)
+        type, max_context_length, qkv_bias_enabled, cross_attention, compute_attention_prior, apply_attention_prior,
+        attention_prior_lookahead, attention_prior_window_left, attention_prior_window_right, max_distance,
+        pos_shift_enabled, dense_context_fmha, use_paged_context_fmha, use_fp8_context_fmha, has_full_attention_mask,
+        use_cache, is_spec_decoding_enabled, spec_decoding_is_generation_length_variable,
+        spec_decoding_max_generation_length, is_mla_enabled, q_lora_rank, kv_lora_rank, qk_nope_head_dim,
+        qk_rope_head_dim, v_head_dim, fuse_fp4_quant, skip_attn, cp_size, cp_rank, cp_group)
 {
     TLLM_CHECK_WITH_INFO(
         !is_mla_enabled, "GPTAttentionPlugin no longer supports MLA. Please use the PyTorch workflow instead.");
@@ -123,6 +125,7 @@ std::string GPTAttentionPlugin::toString(IdxEntry const& entry) const
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(CROSS_KV);
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(CROSS_KV_LENGTH);
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(ENCODER_INPUT_LENGTH);
+        TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(ATTENTION_PRIOR_FOCUS);
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(HOST_CONTEXT_LENGTH);
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(QKV_BIAS_TENSOR);
         TLLM_GPT_ATTN_IDX_ENTRY_TO_STRING(SPEC_DECODING_GENERATION_LENGTHS);
@@ -180,6 +183,7 @@ bool GPTAttentionPlugin::isEntryUsed(IdxEntry const& entry) const
     case IdxEntry::CROSS_KV_LENGTH: return isCrossAttention();
     case IdxEntry::LOGN_SCALING: return isLognScaling();
     case IdxEntry::ENCODER_INPUT_LENGTH: return isCrossAttention();
+    case IdxEntry::ATTENTION_PRIOR_FOCUS: return ApplyAttentionPrior();
     case IdxEntry::HOST_CONTEXT_LENGTH: return mRemovePadding;
     case IdxEntry::QKV_BIAS_TENSOR: return mQKVBiasEnabled;
     case IdxEntry::SPEC_DECODING_GENERATION_LENGTHS: return mIsSpecDecodingEnabled;
@@ -304,7 +308,6 @@ nvinfer1::DimsExprs GPTAttentionPlugin::getOutputDimensions(
     }
     else
     {
-        TLLM_CHECK(outputIndex == 0 || (!mPagedKVCache && useKVCache() && outputIndex == 1));
         if (outputIndex == 0)
         {
             auto ret = inputs[getIdx(IdxEntry::QKV_TENSOR)];
@@ -315,7 +318,27 @@ nvinfer1::DimsExprs GPTAttentionPlugin::getOutputDimensions(
             return ret;
         }
     }
-    return inputs[getIdx(IdxEntry::PAST_KEY_VALUE)];
+    int out_idx = mFuseFp4Quant ? 2 : 1;
+    if (!mPagedKVCache && useKVCache())
+    {
+        if (outputIndex == out_idx)
+        {
+            return inputs[getIdx(IdxEntry::PAST_KEY_VALUE)];
+        }
+        out_idx++;
+    }
+    if (mComputeAttentionPrior)
+    {
+        if (outputIndex == out_idx)
+        {
+            auto shape = nvinfer1::DimsExprs{1,
+                {exprBuilder.operation(DimensionOperation::kPROD, *inputs[getIdx(IdxEntry::ATTENTION_PRIOR_FOCUS)].d[0],
+                    *exprBuilder.constant(mAttentionPriorLookahead))}};
+            return shape;
+        }
+        out_idx++;
+    }
+    TLLM_CHECK_WITH_INFO(false, "Can't fetch output dimension for %d", outputIndex);
 }
 
 bool GPTAttentionPlugin::supportsFormatCombination(
@@ -438,6 +461,16 @@ bool GPTAttentionPlugin::supportsFormatCombination(
         posCaseLine = __LINE__;
         result = inOut[pos].type == nvinfer1::DataType::kINT32;
     }
+    else if (ComputeAttentionPrior() && pos == (nbInputs + nbOutputs - 1))
+    {
+        posCaseLine = __LINE__;
+        result = inOut[pos].type == nvinfer1::DataType::kFLOAT;
+    }
+    else if (ApplyAttentionPrior() && (pos == getIdx(IdxEntry::ATTENTION_PRIOR_FOCUS)))
+    {
+        posCaseLine = __LINE__;
+        result = inOut[pos].type == nvinfer1::DataType::kINT32;
+    }
     else if (isLognScaling() && pos == getIdx(IdxEntry::LOGN_SCALING))
     {
         return inOut[pos].type == nvinfer1::DataType::kFLOAT;
@@ -470,8 +503,8 @@ bool GPTAttentionPlugin::supportsFormatCombination(
         posCaseLine = __LINE__;
         result = (inOut[pos].type == mType) && (inOut[pos].format == TensorFormat::kLINEAR);
     }
-    TLLM_LOG_DEBUG(
-        "%s: pos: %d, result: %d, posCaseLine: %d", __PRETTY_FUNCTION__, pos, static_cast<int>(result), posCaseLine);
+    TLLM_LOG_DEBUG("%s: pos: %d, result: %d, posCaseLine: %d. Number of inputs %d, number of outputs %d",
+        __PRETTY_FUNCTION__, pos, static_cast<int>(result), posCaseLine, nbInputs, nbOutputs);
     return result;
 }
 
@@ -645,16 +678,17 @@ int GPTAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc,
         TLLM_CHECK(mRemovePadding && mPagedKVCache);
     }
 
+    auto nbGenerationSeq = nbSeq - nbContextRequests;
     if (nbContextRequests > 0)
     {
         auto seqIdxBeg = 0;
         auto tokenIdxBeg = 0;
         auto localNbTokens = contextTokenIdxEnd;
-        enqueueSome<T, AttentionOutT, KVCacheBuffer>(seqIdxBeg, nbContextRequests, tokenIdxBeg, localNbTokens,
+        enqueueSome<T, AttentionOutT, KVCacheBuffer>(seqIdxBeg, nbContextRequests, 0, tokenIdxBeg, localNbTokens,
             inputDesc, outputDesc, inputs, outputs, workspace, stream);
     }
 
-    if (auto nbGenerationSeq = nbSeq - nbContextRequests; nbGenerationSeq > 0)
+    if (nbGenerationSeq > 0)
     {
         auto seqIdxBeg = nbContextRequests;
         auto tokenIdxBeg = mCpSize > 1 ? contextTokenIdxEndForCp : contextTokenIdxEnd;
@@ -664,8 +698,8 @@ int GPTAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc,
         auto localNbTokens = mRemovePadding
             ? inputDesc[getIdx(IdxEntry::QKV_TENSOR)].dims.d[0] - tokenIdxBeg
             : inputDesc[getIdx(IdxEntry::QKV_TENSOR)].dims.d[0] * inputDesc[getIdx(IdxEntry::QKV_TENSOR)].dims.d[1];
-        enqueueSome<T, AttentionOutT, KVCacheBuffer>(seqIdxBeg, nbGenerationSeq, tokenIdxBeg, localNbTokens, inputDesc,
-            outputDesc, inputs, outputs, workspace, stream);
+        enqueueSome<T, AttentionOutT, KVCacheBuffer>(seqIdxBeg, nbGenerationSeq, nbContextRequests, tokenIdxBeg,
+            localNbTokens, inputDesc, outputDesc, inputs, outputs, workspace, stream);
     }
 
     sync_check_cuda_error(stream);
@@ -675,8 +709,8 @@ int GPTAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc,
 }
 
 template <typename T, typename AttentionOutT, typename KVCacheBuffer>
-int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32_t tokenIdxBeg, int32_t localNbTokens,
-    nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
+int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32_t contextNbSeq, int32_t tokenIdxBeg,
+    int32_t localNbTokens, nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
     void const* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream)
 {
     //     relative_attention_bias [head_num, max_seq_len, max_seq_len] (optional in relative position)
@@ -787,7 +821,7 @@ int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32
     int max_encoder_context_len = isCrossAttention() ? inputDesc[getIdx(IdxEntry::CROSS_KV_LENGTH)].dims.d[0] : 0;
     // for enc-dec model, since decoder_input_ids could be longer than 1,
     // such model has an encoder context (for cross attn) and an decoder context (for self attn)
-    // clarify 3 lens:
+    // clarify 3 lensii:
     // -- max_context_q_len: len of decoder input. No "max" concept, it's what it is given.
     //                     Also called (decoder_)input_seq_length, normally 1 for encoder-decoder start token
     // -- max_seq_len: max allowed len of decoder output, i.e. final results
@@ -1118,6 +1152,30 @@ int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32
             enqueue_params.spec_decoding_is_generation_length_variable = mSpecDecodingIsGenerationLengthVariable;
             enqueue_params.spec_decoding_max_generation_length = mSpecDecodingMaxGenerationLength;
         }
+        if (isCrossAttention())
+        {
+            if (mComputeAttentionPrior)
+            {
+                // the attention prior is always last
+                float* attention_prior_scores_out = static_cast<float*>(outputs[getNbOutputs() - 1]);
+                // advance the prior scores pointer, skipping the space reserved for context requests
+                attention_prior_scores_out += contextNbSeq * mAttentionPriorLookahead;
+                enqueue_params.attention_prior_scores = attention_prior_scores_out;
+            }
+            else
+            {
+                enqueue_params.attention_prior_scores = nullptr;
+            }
+            if (mApplyAttentionPrior || mComputeAttentionPrior)
+            {
+                enqueue_params.attention_prior_focus
+                    = static_cast<int const*>(inputs[getIdx(IdxEntry::ATTENTION_PRIOR_FOCUS)]);
+            }
+            else
+            {
+                enqueue_params.attention_prior_focus = nullptr;
+            }
+        }
         if (mFuseFp4Quant)
         {
             enqueue_params.start_token_idx_sf = tokenIdxBeg;
@@ -1226,26 +1284,43 @@ nvinfer1::DataType GPTAttentionPlugin::getOutputDataType(
 {
     if (mFuseFp4Quant)
     {
-        TLLM_CHECK(index == 0 || index == 1 || (!mPagedKVCache && useKVCache() && index == 2));
-    }
-    else
-    {
-        TLLM_CHECK(index == 0 || (!mPagedKVCache && useKVCache() && index == 1));
-    }
-    if (index == 0)
-    {
-        if (mFuseFp4Quant)
+        if (index == 0)
         {
             return nvinfer1::DataType::kFP4;
         }
-        return mFP8ContextFMHA && mEnableContextFMHA ? nvinfer1::DataType::kFP8
-                                                     : inputTypes[getIdx(IdxEntry::QKV_TENSOR)];
+        if (index == 1)
+        {
+            return nvinfer1::DataType::kFP8;
+        }
     }
-    if (mFuseFp4Quant && index == 1)
+    else
     {
-        return nvinfer1::DataType::kFP8;
+        if (index == 0)
+        {
+            return mFP8ContextFMHA && mEnableContextFMHA ? nvinfer1::DataType::kFP8
+                                                         : inputTypes[getIdx(IdxEntry::QKV_TENSOR)];
+        }
     }
-    return inputTypes[getIdx(IdxEntry::PAST_KEY_VALUE)];
+    int out_idx = mFuseFp4Quant ? 2 : 1;
+    if (!mPagedKVCache && useKVCache())
+    {
+        if (index == out_idx)
+        {
+            return inputTypes[getIdx(IdxEntry::PAST_KEY_VALUE)];
+        }
+        out_idx++;
+    }
+
+    if (mComputeAttentionPrior)
+    {
+        if (index == out_idx)
+        {
+            return nvinfer1::DataType::kFLOAT;
+        }
+        out_idx++;
+    }
+
+    TLLM_CHECK_WITH_INFO(false, "Can't fetch output type for %d", index);
 }
 
 // IPluginV2 Methods
@@ -1263,7 +1338,11 @@ char const* GPTAttentionPlugin::getPluginVersion() const noexcept
 int GPTAttentionPlugin::getNbOutputs() const noexcept
 {
     int nbOutputs = mFuseFp4Quant ? 2 : 1;
-    if (!mPagedKVCache && useKVCache())
+    if (!mPagedKVCache && useKVCache()) // corresponds to PAST_KEY_VALUE
+    {
+        nbOutputs += 1;
+    }
+    if (mComputeAttentionPrior) // corresponds to ATTENTION_PRIOR_SCORES
     {
         nbOutputs += 1;
     }
@@ -1340,6 +1419,11 @@ IPluginV2* GPTAttentionPluginCreator::createPlugin(char const* name, PluginField
             p.getScalar<int32_t>("max_context_length").value(),
             static_cast<bool>(p.getScalar<int8_t>("qkv_bias_enabled").value()),
             static_cast<bool>(p.getScalar<int8_t>("do_cross_attention").value()),
+            static_cast<bool>(p.getScalar<int8_t>("compute_attention_prior").value()),
+            static_cast<bool>(p.getScalar<int8_t>("apply_attention_prior").value()),
+            p.getScalar<int32_t>("attention_prior_lookahead").value(),
+            p.getScalar<int32_t>("attention_prior_window_left").value(),
+            p.getScalar<int32_t>("attention_prior_window_right").value(),
             static_cast<int32_t>(p.getScalar<int32_t>("max_distance").value()),
             static_cast<bool>(p.getScalar<int8_t>("pos_shift_enabled").value()),
             static_cast<bool>(p.getScalar<int8_t>("dense_context_fmha").value()),

--- a/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.h
+++ b/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.h
@@ -114,13 +114,15 @@ public:
         tensorrt_llm::kernels::AttentionMaskType mask_type,
         tensorrt_llm::kernels::BlockSparseParams block_sparse_params, bool paged_kv_cache, int tokens_per_block,
         nvinfer1::DataType type, int32_t max_context_length, bool qkv_bias_enabled, bool cross_attention = false,
-        int max_distance = 0, bool pos_shift_enabled = false, bool dense_context_fmha = false,
-        bool use_paged_context_fmha = true, bool use_fp8_context_fmha = true, bool has_full_attention_mask = false,
-        bool use_cache = true, bool is_spec_decoding_enabled = false,
-        bool spec_decoding_is_generation_length_variable = false, int spec_decoding_max_generation_length = 1,
-        bool is_mla_enabled = false, int q_lora_rank = 0, int kv_lora_rank = 0, int qk_nope_head_dim = 0,
-        int qk_rope_head_dim = 0, int v_head_dim = 0, bool fuse_fp4_quant = false, bool skip_attn = false,
-        int cp_size = 1, int cp_rank = 0, std::set<int32_t> cp_group = {});
+        bool compute_attention_prior = false, bool apply_attention_prior = false, int attention_prior_lookahead = 5,
+        int attention_prior_window_left = 1, int attention_prior_window_right = 5, int max_distance = 0,
+        bool pos_shift_enabled = false, bool dense_context_fmha = false, bool use_paged_context_fmha = true,
+        bool use_fp8_context_fmha = true, bool has_full_attention_mask = false, bool use_cache = true,
+        bool is_spec_decoding_enabled = false, bool spec_decoding_is_generation_length_variable = false,
+        int spec_decoding_max_generation_length = 1, bool is_mla_enabled = false, int q_lora_rank = 0,
+        int kv_lora_rank = 0, int qk_nope_head_dim = 0, int qk_rope_head_dim = 0, int v_head_dim = 0,
+        bool fuse_fp4_quant = false, bool skip_attn = false, int cp_size = 1, int cp_rank = 0,
+        std::set<int32_t> cp_group = {});
 
     GPTAttentionPlugin(void const* data, size_t length);
 
@@ -173,9 +175,10 @@ public:
 
 private:
     template <typename T, typename AttentionOutT, typename KVCacheBuffer>
-    int enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32_t tokenIdxBeg, int32_t localNbTokens,
-        nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
-        void const* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream);
+    int enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32_t contextNbSeq, int32_t tokenIdxBeg,
+        int32_t localNbTokens, nvinfer1::PluginTensorDesc const* inputDesc,
+        nvinfer1::PluginTensorDesc const* outputDesc, void const* const* inputs, void* const* outputs, void* workspace,
+        cudaStream_t stream);
 
     using IndexType = std::int32_t;
 
@@ -210,6 +213,7 @@ private:
         CROSS_KV,
         CROSS_KV_LENGTH,
         ENCODER_INPUT_LENGTH,
+        ATTENTION_PRIOR_FOCUS,
         HOST_CONTEXT_LENGTH,
         QKV_BIAS_TENSOR,
         SPEC_DECODING_GENERATION_LENGTHS,

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -138,7 +138,7 @@ void initBindings(pybind11::module_& m)
         .def_property("streaming", &GenLlmReq::isStreaming, &GenLlmReq::setStreaming)
         .def_readwrite("end_id", &GenLlmReq::mEndId)
         .def_readwrite("pad_id", &GenLlmReq::mPadId)
-        .def_readwrite("seq_slot", &GenLlmReq::mSeqSlot)
+        .def_readwrite("seq_slots", &GenLlmReq::mSeqSlots)
         .def_property_readonly("return_log_probs", &GenLlmReq::returnLogProbs)
         .def_property_readonly("return_context_logits", &GenLlmReq::getReturnContextLogits)
         .def_property_readonly("return_generation_logits", &GenLlmReq::getReturnGenerationLogits)
@@ -287,7 +287,8 @@ void initBindings(pybind11::module_& m)
                      std::optional<tb::LlmRequest::RequestIdType> client_id, executor::PriorityType priority,
                      std::optional<at::Tensor> encoder_input_features,
                      std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
-                     std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
+                     std::optional<at::Tensor> decoder_context_features, std::optional<at::Tensor> cross_attention_mask,
+                     tb::LlmRequestType llm_request_type,
                      std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
                      tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
                      std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
@@ -322,6 +323,7 @@ void initBindings(pybind11::module_& m)
                      auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
                      auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
                      auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
+                     auto decoder_context_features_tensor_ptr = makeOptionalTensor(decoder_context_features);
                      auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
                      auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
 
@@ -334,9 +336,9 @@ void initBindings(pybind11::module_& m)
                          return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
                          exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
                          encoder_input_tokens, return_encoder_output, client_id, priority,
-                         encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
-                         llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
-                         skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
+                         encoder_input_features_tensor_ptr, encoder_output_length, decoder_context_features_tensor_ptr,
+                         cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids, num_return_sequences,
+                         eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
                          language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id, arrival_time};
                  }),
             py::arg("request_id"), py::arg("max_new_tokens"), py::arg("input_tokens"), py::arg("sampling_config"),
@@ -356,7 +358,8 @@ void initBindings(pybind11::module_& m)
             py::arg("apply_logits_post_processor_batched") = false, py::arg("encoder_input_tokens") = std::nullopt,
             py::arg("return_encoder_output") = false, py::arg("client_id") = std::nullopt,
             py::arg("priority") = executor::Request::kDefaultPriority, py::arg("encoder_input_features") = std::nullopt,
-            py::arg("encoder_output_len") = std::nullopt, py::arg("cross_attention_mask") = std::nullopt,
+            py::arg("encoder_output_len") = std::nullopt, py::arg("decoder_context_features") = std::nullopt,
+            py::arg("cross_attention_mask") = std::nullopt,
             py::arg_v("llm_request_type", tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
                 "LlmRequestType.LLMREQUEST_TYPE_CONTEXT_AND_GENERATION"),
             py::arg("input_token_extra_ids") = std::nullopt, py::arg("num_return_sequences") = 1,

--- a/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.cpp
@@ -114,6 +114,7 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mPriority,                                                 //
         from_torch(mEncoderInputFeatures),                         //
         mEncoderOutputLength,                                      //
+        from_torch(mDecoderContextFeatures),                       //
         from_torch(mCrossAttentionMask),                           //
         getLlmRequestType(),                                       //
         std::nullopt,                                              // inputTokenExtraIds

--- a/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.h
@@ -76,6 +76,7 @@ public:
         executor::PriorityType priority = executor::Request::kDefaultPriority,
         std::optional<TensorPtr> encoderInputFeatures = std::nullopt,
         std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<TensorPtr> decoderContextFeatures = std::nullopt,
         std::optional<TensorPtr> crossAttentionMask = std::nullopt,
         tb::LlmRequestType llmRequestType = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         std::optional<VecTokenExtraIds> inputTokenExtraIds = std::nullopt, SizeType32 numReturnSequences = 1,
@@ -135,6 +136,7 @@ public:
             priority,                                                                                            //
             encoderInputFeatures,                                                                                //
             encoderOutputLength,                                                                                 //
+            decoderContextFeatures,                                                                              //
             crossAttentionMask,                                                                                  //
             llmRequestType,                                                                                      //
             inputTokenExtraIds                                                                                   //

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -77,51 +77,53 @@ void initRequestBindings(pybind11::module_& m)
     };
     auto samplingConfigSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 19)
+        if (state.size() != 20)
         {
             throw std::runtime_error("Invalid SamplingConfig state!");
         }
-        return tle::SamplingConfig(state[0].cast<SizeType32>(),      // BeamWidth
-            state[1].cast<std::optional<SizeType32>>(),              // TopK
-            state[2].cast<std::optional<FloatType>>(),               // TopP
-            state[3].cast<std::optional<FloatType>>(),               // TopPMin
-            state[4].cast<std::optional<tle::TokenIdType>>(),        // TopPResetIds
-            state[5].cast<std::optional<FloatType>>(),               // TopPDecay
-            state[6].cast<std::optional<tle::RandomSeedType>>(),     // Seed
-            state[7].cast<std::optional<FloatType>>(),               // Temperature
-            state[8].cast<std::optional<SizeType32>>(),              // MinTokens
-            state[9].cast<std::optional<FloatType>>(),               // BeamSearchDiversityRate
-            state[10].cast<std::optional<FloatType>>(),              // RepetitionPenalty
-            state[11].cast<std::optional<FloatType>>(),              // PresencePenalty
-            state[12].cast<std::optional<FloatType>>(),              // FrequencyPenalty
-            state[13].cast<std::optional<FloatType>>(),              // LengthPenalty
-            state[14].cast<std::optional<SizeType32>>(),             // EarlyStopping
-            state[15].cast<std::optional<SizeType32>>(),             // NoRepeatNgramSize
-            state[16].cast<std::optional<SizeType32>>(),             // NumReturnSequences
-            state[17].cast<std::optional<FloatType>>(),              // MinP
-            state[18].cast<std::optional<std::vector<SizeType32>>>() // BeamWidthArray
+        return tle::SamplingConfig(state[0].cast<SizeType32>(),       // BeamWidth
+            state[1].cast<std::optional<SizeType32>>(),               // TopK
+            state[2].cast<std::optional<FloatType>>(),                // TopP
+            state[3].cast<std::optional<FloatType>>(),                // TopPMin
+            state[4].cast<std::optional<tle::TokenIdType>>(),         // TopPResetIds
+            state[5].cast<std::optional<FloatType>>(),                // TopPDecay
+            state[6].cast<std::optional<tle::RandomSeedType>>(),      // Seed
+            state[7].cast<std::optional<FloatType>>(),                // Temperature
+            state[8].cast<std::optional<SizeType32>>(),               // MinTokens
+            state[9].cast<std::optional<FloatType>>(),                // BeamSearchDiversityRate
+            state[10].cast<std::optional<FloatType>>(),               // RepetitionPenalty
+            state[11].cast<std::optional<FloatType>>(),               // PresencePenalty
+            state[12].cast<std::optional<FloatType>>(),               // FrequencyPenalty
+            state[13].cast<std::optional<FloatType>>(),               // LengthPenalty
+            state[14].cast<std::optional<SizeType32>>(),              // EarlyStopping
+            state[15].cast<std::optional<SizeType32>>(),              // NoRepeatNgramSize
+            state[16].cast<std::optional<SizeType32>>(),              // NumReturnSequences
+            state[17].cast<std::optional<FloatType>>(),               // MinP
+            state[18].cast<std::optional<std::vector<SizeType32>>>(), // BeamWidthArray
+            state[19].cast<std::optional<FloatType>>()                // CfgScale
         );
     };
     py::class_<tle::SamplingConfig>(m, "SamplingConfig")
         .def(py::init<tle::SizeType32,
-                 std::optional<tle::SizeType32> const&,             // beamWidth
-                 std::optional<tle::FloatType> const&,              // topP
-                 std::optional<tle::FloatType> const&,              // topPMin
-                 std::optional<tle::TokenIdType> const&,            // topPResetIds
-                 std::optional<tle::FloatType> const&,              // topPDecay
-                 std::optional<tle::RandomSeedType> const&,         // seed
-                 std::optional<tle::FloatType> const&,              // temperature
-                 std::optional<tle::SizeType32> const&,             // minTokens
-                 std::optional<tle::FloatType> const&,              // beamSearchDiversityRate
-                 std::optional<tle::FloatType> const&,              // repetitionPenalty
-                 std::optional<tle::FloatType> const&,              // presencePenalty
-                 std::optional<tle::FloatType> const&,              // frequencyPenalty
-                 std::optional<tle::FloatType> const&,              // lengthPenalty
-                 std::optional<tle::SizeType32> const&,             // earlyStopping
-                 std::optional<tle::SizeType32> const&,             // noRepeatNgramSize
-                 std::optional<tle::SizeType32> const&,             // numReturnSequences
-                 std::optional<tle::FloatType> const&,              // minP
-                 std::optional<std::vector<tle::SizeType32>> const& // beamWidthArray
+                 std::optional<tle::SizeType32> const&,              // beamWidth
+                 std::optional<tle::FloatType> const&,               // topP
+                 std::optional<tle::FloatType> const&,               // topPMin
+                 std::optional<tle::TokenIdType> const&,             // topPResetIds
+                 std::optional<tle::FloatType> const&,               // topPDecay
+                 std::optional<tle::RandomSeedType> const&,          // seed
+                 std::optional<tle::FloatType> const&,               // temperature
+                 std::optional<tle::SizeType32> const&,              // minTokens
+                 std::optional<tle::FloatType> const&,               // beamSearchDiversityRate
+                 std::optional<tle::FloatType> const&,               // repetitionPenalty
+                 std::optional<tle::FloatType> const&,               // presencePenalty
+                 std::optional<tle::FloatType> const&,               // frequencyPenalty
+                 std::optional<tle::FloatType> const&,               // lengthPenalty
+                 std::optional<tle::SizeType32> const&,              // earlyStopping
+                 std::optional<tle::SizeType32> const&,              // noRepeatNgramSize
+                 std::optional<tle::SizeType32> const&,              // numReturnSequences
+                 std::optional<tle::FloatType> const&,               // minP
+                 std::optional<std::vector<tle::SizeType32>> const&, // beamWidthArray
+                 std::optional<tle::FloatType> const&                // CfgScale
                  >(),
             // clang-format off
             py::arg("beam_width") = 1,
@@ -143,7 +145,8 @@ void initRequestBindings(pybind11::module_& m)
             py::arg("no_repeat_ngram_size") = py::none(),
             py::arg("num_return_sequences") = py::none(),
             py::arg("min_p") = py::none(),
-            py::arg("beam_width_array") = py::none())               // clang-format on
+            py::arg("beam_width_array") = py::none(),
+            py::arg("cfg_scale") = py::none())                       // clang-format on
         .def_property("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
         .def_property("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
         .def_property("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
@@ -170,6 +173,7 @@ void initRequestBindings(pybind11::module_& m)
         .def_property("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
         .def_property(
             "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
+        .def_property("cfg_scale", &tle::SamplingConfig::getCfgScale, &tle::SamplingConfig::setCfgScale)
         .def(py::pickle(samplingConfigGetstate, samplingConfigSetstate));
 
     auto additionalModelOutputGetstate
@@ -525,12 +529,12 @@ void initRequestBindings(pybind11::module_& m)
             self.getLogitsPostProcessorName(), self.getLogitsPostProcessor(), self.getEncoderInputTokenIds(),
             self.getClientId(), self.getReturnAllGeneratedTokens(), self.getPriority(), self.getRequestType(),
             self.getContextPhaseParams(), self.getEncoderInputFeatures(), self.getEncoderOutputLength(),
-            self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
-            self.getGuidedDecodingParams(), self.getCacheSaltID());
+            self.getDecoderContextFeatures(), self.getCrossAttentionMask(), self.getEagleConfig(),
+            self.getSkipCrossAttnBlocks(), self.getGuidedDecodingParams(), self.getCacheSaltID(), self.getNumVocabs());
     };
     auto requestSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 34)
+        if (state.size() != 36)
         {
             throw std::runtime_error("Invalid Request state!");
         }
@@ -549,9 +553,10 @@ void initRequestBindings(pybind11::module_& m)
             state[22].cast<std::optional<IdType>>(), state[23].cast<bool>(), state[24].cast<tle::PriorityType>(),
             state[25].cast<tle::RequestType>(), state[26].cast<std::optional<tle::ContextPhaseParams>>(),
             state[27].cast<std::optional<tle::Tensor>>(), state[28].cast<std::optional<SizeType32>>(),
-            state[29].cast<std::optional<tle::Tensor>>(), 1, state[30].cast<std::optional<tle::EagleConfig>>(),
-            state[31].cast<std::optional<tle::Tensor>>(), state[32].cast<std::optional<tle::GuidedDecodingParams>>(),
-            state[33].cast<std::optional<tle::CacheSaltIDType>>());
+            state[29].cast<std::optional<tle::Tensor>>() state[30].cast<std::optional<tle::Tensor>>(), 1,
+            state[31].cast<std::optional<tle::EagleConfig>>(), state[32].cast<std::optional<tle::Tensor>>(),
+            state[33].cast<std::optional<tle::GuidedDecodingParams>>(),
+            state[34].cast<std::optional<tle::CacheSaltIDType>>(), state[35].cast<SizeType32>());
     };
 
     py::class_<tle::Request> request(m, "Request", pybind11::dynamic_attr());
@@ -585,6 +590,7 @@ void initRequestBindings(pybind11::module_& m)
                  std::optional<tle::ContextPhaseParams>,        // contextPhaseParams
                  std::optional<tle::Tensor>,                    // encoderInputFeatures
                  std::optional<tle::SizeType32>,                // encoderOutputLength
+                 std::optional<tle::Tensor>,                    // decoderContextFeatures
                  std::optional<tle::Tensor>,                    // crossAttentionMask
                  SizeType32,                                    // numReturnSequences
                  std::optional<tle::EagleConfig>,               // eagleConfig
@@ -592,7 +598,8 @@ void initRequestBindings(pybind11::module_& m)
                  std::optional<tle::GuidedDecodingParams>,      // guidedDecodingParams
                  std::optional<tle::SizeType32>,                // languageAdapterUid
                  std::optional<tle::MillisecondsType>,          // allottedTimeMs
-                 std::optional<tle::CacheSaltIDType>            // cacheSaltID
+                 std::optional<tle::CacheSaltIDType>,           // cacheSaltID
+                 tle::SizeType32                                // numVocabs
                  >(),
             // clang-format off
         py::arg("input_token_ids"),
@@ -626,6 +633,7 @@ void initRequestBindings(pybind11::module_& m)
         py::arg("context_phase_params") = py::none(),
         py::arg("encoder_input_features") = py::none(),
         py::arg("encoder_output_length") = py::none(),
+        py::arg("decoder_context_features") = py::none(),
         py::arg("cross_attention_mask") = py::none(),
         py::arg("num_return_sequences") = 1,
         py::arg("eagle_config") = py::none(),
@@ -633,7 +641,8 @@ void initRequestBindings(pybind11::module_& m)
         py::arg("guided_decoding_params") = py::none(),
         py::arg("language_adapter_uid") = py::none(),
         py::arg("allotted_time_ms") = py::none(),
-        py::arg("cache_salt_id") = py::none()
+        py::arg("cache_salt_id") = py::none(),
+        py::arg()"num_vocabs") = 1
     )             // clang-format on
         .def_property_readonly("input_token_ids", &tle::Request::getInputTokenIds)
         .def_property_readonly("max_tokens", &tle::Request::getMaxTokens)
@@ -670,6 +679,8 @@ void initRequestBindings(pybind11::module_& m)
         .def_property("request_type", &tle::Request::getRequestType, &tle::Request::setRequestType)
         .def_property(
             "encoder_input_features", &tle::Request::getEncoderInputFeatures, &tle::Request::setEncoderInputFeatures)
+        def_property(
+            "decoder_context_features", &tle::Request::getDecoderContextFeatures, &tle::Request::setDecoderContextFeatures)
         .def_property(
             "cross_attention_mask", &tle::Request::getCrossAttentionMask, &tle::Request::setCrossAttentionMask)
         .def_property("eagle_config", &tle::Request::getEagleConfig, &tle::Request::setEagleConfig)
@@ -679,6 +690,7 @@ void initRequestBindings(pybind11::module_& m)
             "guided_decoding_params", &tle::Request::getGuidedDecodingParams, &tle::Request::setGuidedDecodingParams)
         .def_property("allotted_time_ms", &tle::Request::getAllottedTimeMs, &tle::Request::setAllottedTimeMs)
         .def_property("cache_salt_id", &tle::Request::getCacheSaltID, &tle::Request::setCacheSaltID)
+        .def_property("num_vocabs", &tle::Request::getNumVocabs, &tle::Request::setNumVocabs)
         .def_property(
             "context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
         .def(py::pickle(requestGetstate, requestSetstate));

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -388,7 +388,7 @@ void initBindings(pybind11::module_& m)
             py::call_guard<py::gil_scoped_release>())
         .def("setup", &tr::GptDecoderBatched::setup, py::arg("mode"), py::arg("max_num_sequences"),
             py::arg("max_beam_width"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"),
-            py::call_guard<py::gil_scoped_release>())
+            py::arg("vocab_size") = 0, py::call_guard<py::gil_scoped_release>())
         .def("forward_async", &tr::GptDecoderBatched::forwardAsync, py::arg("decoder_state"), py::arg("input"),
             py::call_guard<py::gil_scoped_release>())
         .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, py::return_value_policy::reference)

--- a/cpp/tensorrt_llm/runtime/decoderState.cpp
+++ b/cpp/tensorrt_llm/runtime/decoderState.cpp
@@ -459,9 +459,10 @@ void DecoderState::disableLookahead(RequestVector const& genRequests)
 
     for (auto const& llmReq : genRequests)
     {
-        if (llmReq->mSeqSlot)
+        if (!llmReq->mSeqSlots.empty())
+
         {
-            setNumDecodingEngineTokens(llmReq->mSeqSlot.value(), 1);
+            setNumDecodingEngineTokens(llmReq->mSeqSlots.at(0), 1);
         }
     }
 

--- a/cpp/tensorrt_llm/runtime/iTensor.cpp
+++ b/cpp/tensorrt_llm/runtime/iTensor.cpp
@@ -52,10 +52,6 @@ ITensor::UniquePtr ITensor::slice(SharedPtr tensor, Shape const& offsetDims, ITe
 
     if (TLLM_LIKELY(offsetDims.nbDims > 0))
     {
-        TLLM_LOG_INFO(
-            "offsetDims.nbDims - 1:%d, offsetDims.d[offsetDims.nbDims - 1]: %d, size: %d, shape.d[offsetDims.nbDims - "
-            "1]: %d",
-            offsetDims.nbDims - 1, offsetDims.d[offsetDims.nbDims - 1], size, shape.d[offsetDims.nbDims - 1]);
         TLLM_CHECK(offsetDims.d[offsetDims.nbDims - 1] + size <= shape.d[offsetDims.nbDims - 1]);
         offset += offsetDims.d[offsetDims.nbDims - 1] * strides.d[offsetDims.nbDims - 1];
     }

--- a/cpp/tensorrt_llm/runtime/iTensor.cpp
+++ b/cpp/tensorrt_llm/runtime/iTensor.cpp
@@ -52,6 +52,10 @@ ITensor::UniquePtr ITensor::slice(SharedPtr tensor, Shape const& offsetDims, ITe
 
     if (TLLM_LIKELY(offsetDims.nbDims > 0))
     {
+        TLLM_LOG_INFO(
+            "offsetDims.nbDims - 1:%d, offsetDims.d[offsetDims.nbDims - 1]: %d, size: %d, shape.d[offsetDims.nbDims - "
+            "1]: %d",
+            offsetDims.nbDims - 1, offsetDims.d[offsetDims.nbDims - 1], size, shape.d[offsetDims.nbDims - 1]);
         TLLM_CHECK(offsetDims.d[offsetDims.nbDims - 1] + size <= shape.d[offsetDims.nbDims - 1]);
         offset += offsetDims.d[offsetDims.nbDims - 1] * strides.d[offsetDims.nbDims - 1];
     }

--- a/cpp/tensorrt_llm/runtime/promptTuningParams.cpp
+++ b/cpp/tensorrt_llm/runtime/promptTuningParams.cpp
@@ -51,13 +51,13 @@ void PromptTuningParams::fillTasksTensor(TensorPtr tasksHost, SizeType32 const b
             if (bid < numContextRequests)
             {
                 totalInputSize += reqPromptLengths[bid];
-                promptTasksHost.insert(promptTasksHost.end(), reqPromptLengths[bid], taskId);
+                promptTasksHost.insert(promptTasksHost.end(), reqPromptLengths[bid] * numVocabs, taskId);
             }
             else
             {
                 for (SizeType32 beam = 0; beam < reqBeamWidths[bid]; ++beam)
                 {
-                    promptTasksHost.insert(promptTasksHost.end(), 1, taskId);
+                    promptTasksHost.insert(promptTasksHost.end(), numVocabs, taskId);
                     totalInputSize++;
                 }
             }
@@ -80,7 +80,7 @@ void PromptTuningParams::fillTasksTensor(TensorPtr tasksHost, SizeType32 const b
     if (packedInput)
     {
         tasks = manager.copyFrom(
-            promptTasksHost, runtime::ITensor::makeShape({totalInputSize}), runtime::MemoryType::kGPU);
+            promptTasksHost, runtime::ITensor::makeShape({totalInputSize * numVocabs}), runtime::MemoryType::kGPU);
     }
     else
     {

--- a/cpp/tensorrt_llm/runtime/runtimeKernels.h
+++ b/cpp/tensorrt_llm/runtime/runtimeKernels.h
@@ -43,6 +43,9 @@ void invokeGatherBatch(IBuffer& buffer, IBuffer const& values, IBuffer const& sl
 void invokeCopyBatch(IBuffer const& srcBuffer, IBuffer& dstBuffer, IBuffer const& srcOffsets, IBuffer const& dstOffsets,
     IBuffer const& sizes, std::size_t maxStride, CudaStream const& stream);
 
+template <typename T>
+void invokeAdd(IBuffer& buffer, T value, CudaStream const& stream);
+
 void scatterTensor(ITensor& output, ITensor const& input, SizeType32 beamWidth, CudaStream const& stream);
 
 void tileTensor(ITensor& output, ITensor const& input, SizeType32 beamWidth, CudaStream const& stream);

--- a/cpp/tests/e2e_tests/batch_manager/guidedDecoderTest.cpp
+++ b/cpp/tests/e2e_tests/batch_manager/guidedDecoderTest.cpp
@@ -120,10 +120,10 @@ public:
         auto llmReq1 = std::make_shared<LlmRequest>(1, 100, std::make_shared<VecTokens>(10), SamplingConfig(), false);
         texec::GuidedDecodingParams guidedDecodingParams(texec::GuidedDecodingParams::GuideType::kJSON);
         llmReq1->setGuidedDecodingParams(guidedDecodingParams);
-        llmReq1->mSeqSlot = 1;
+        llmReq1->mSeqSlots.push_back(1);
 
         auto llmReq2 = std::make_shared<LlmRequest>(1, 100, std::make_shared<VecTokens>(10), SamplingConfig(), false);
-        llmReq2->mSeqSlot = 2;
+        llmReq2->mSeqSlots.push_back(2);
 
         RequestVector contextRequests{llmReq1, llmReq2};
         RequestVector generationRequests{};

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -54,7 +54,7 @@ TEST_F(LlmRequestTest, fromExecutorRequest)
         EXPECT_EQ(llmReq.getOrigPromptLen(), inputTokens.size());
         EXPECT_EQ(llmReq.getMaxSentTokenLen(), inputTokens.size());
         EXPECT_EQ(llmReq.getState(), tb::LlmRequestState::kCONTEXT_INIT);
-        EXPECT_FALSE(llmReq.mSeqSlot);
+        EXPECT_FALSE(llmReq.mSeqSlots.empty());
         // No speculative decoding config, draft tokens should be empty
         EXPECT_EQ(llmReq.getDraftTokens()->size(), 0);
         EXPECT_FALSE(llmReq.getEmbeddingBias().has_value());
@@ -488,7 +488,7 @@ TEST_F(LlmRequestTest, testCreateRequests)
         EXPECT_EQ(childReq1->getState(), llmReq.getState());
         EXPECT_EQ(childReq1->mSamplingConfig.randomSeed.value(), std::vector<texec::RandomSeedType>{8});
         EXPECT_EQ(llmReq2.mSamplingConfig.randomSeed.value(), std::vector<texec::RandomSeedType>{7});
-        EXPECT_FALSE(childReq1->mSeqSlot);
+        EXPECT_FALSE(childReq1->mSeqSlots.empty()));
     }
 
     {

--- a/examples/models/core/enc_dec/convert_checkpoint.py
+++ b/examples/models/core/enc_dec/convert_checkpoint.py
@@ -1734,6 +1734,7 @@ def convert_checkpoint(args):
         'hidden_size': decoder_config.hidden_size,
         'norm_epsilon': decoder_config.layernorm_eps,
         'vocab_size': decoder_config.vocab_size,
+        'vocab_sizes': [decoder_config.vocab_size],
         'position_embedding_type': decoder_config.position_embedding_type,
         'hidden_act': decoder_config.hidden_act,
         'quantization': {

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -909,7 +909,9 @@ def optimize_model_with_config(model: PretrainedModel,
     if build_config.plugin_config.lora_plugin is not None:
         model.use_lora(build_config.lora_config)
 
-    is_enc_dec = model.config.architecture in ["EncoderModel", "DecoderModel"]
+    is_enc_dec = model.config.architecture in [
+        "EncoderModel", "DecoderModel", "T5TTSEncoderModel", "T5TTSDecoderModel"
+    ]
     # FusedMLP does not support RecurrentGemma FP8 currently.
     is_recurrent_gemma = model.config.architecture in [
         "RecurrentGemmaForCausalLM"
@@ -1349,8 +1351,11 @@ def build(model: PretrainedModel, build_config: BuildConfig) -> Engine:
             build_config.lora_config.lora_target_modules
         }
 
-        if model.config.architecture == "DecoderModel" or "mllama" in model.config.architecture.lower(
-        ):
+
+        if "mllama" in model.config.architecture.lower() or \
+            model.config.architecture == "DecoderModel" or \
+            model.config.architecture == "T5TTSDecoderModel":
+
             prepare_input_args["max_seq_len"] = build_config.max_seq_len
             prepare_input_args[
                 "max_decoder_input_len"] = build_config.max_input_len

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -5280,9 +5280,16 @@ def gpt_attention(
     host_kv_cache_pool_pointers: Tensor = None,
     host_kv_cache_pool_mapping: Tensor = None,
     do_cross_attention: bool = False,
+    compute_attention_prior: bool = False,
+    apply_attention_prior: bool = False,
+    attention_prior_lookahead: int = 5,
+    attention_prior_window_left: int = 1,
+    attention_prior_window_right: int = 5,
     cross_kv: Optional[Tensor] = None,  # for cross attention
     cross_kv_length: Optional[Tensor] = None,  # for cross attention
     encoder_input_lengths: Optional[Tensor] = None,  # for cross attention
+    attention_prior_focus: Optional[
+        Tensor] = None,  # when applying prior is enabled
     relative_attention_bias: Optional[Tensor] = None,  # for relative attention
     logn_scaling: Optional[Tensor] = None,  # for logn scaling
     max_distance: int = 0,  # for relative attention
@@ -5504,6 +5511,16 @@ def gpt_attention(
         do_cross_attention: bool = False
             Do we use this as cross attention instead of self attention,
 
+        compute_attention_prior: bool = False,
+            Whether to accumulate attention prior scores in the kernel.
+            only valid for generation requests and cross attention.
+            uses attention_prior_scores provided lower
+
+        apply_attention_prior: bool = False,
+            Whether to apply attention prior.
+            only valid for generation requests and cross attention.
+            uses attention_prior_focus provided lower
+
         cross_kv: Tensor = None
             The KV tensor of encoder output hidden states. Its shape is [batch_size, max_seqlen, 2 * kvHeadNum * headSize] in padded mode and [1, num_tokens, 2 * kvHeadNum * headSize] in
             packed mode,
@@ -5513,6 +5530,10 @@ def gpt_attention(
 
         encoder_input_lengths: Tensor
             The tensor that stores the length of each encoder input sequence. Its shape is [batch_size],
+
+        attention_prior_focus: Optional[Tensor] = None
+            (B,) for each sequence specifies where start of the region on which to focus in cross attention.
+            rest of the encoder outputs are masked out.
 
         logn_scaling: Tensor = None
             The logn scaling tensor [max_position_embedding_len], which is applied to q in order to help extrapolation
@@ -5790,6 +5811,26 @@ def gpt_attention(
         "do_cross_attention",
         np.array(np.int8(do_cross_attention), dtype=np.int8),
         trt.PluginFieldType.INT8)
+    compute_attention_prior_field = trt.PluginField(
+        "compute_attention_prior",
+        np.array(np.int8(compute_attention_prior), dtype=np.int8),
+        trt.PluginFieldType.INT8)
+    apply_attention_prior_field = trt.PluginField(
+        "apply_attention_prior",
+        np.array(np.int8(apply_attention_prior), dtype=np.int8),
+        trt.PluginFieldType.INT8)
+    attention_prior_lookahead_field = trt.PluginField(
+        "attention_prior_lookahead",
+        np.array(attention_prior_lookahead, dtype=np.int32),
+        trt.PluginFieldType.INT32)
+    attention_prior_window_left_field = trt.PluginField(
+        "attention_prior_window_left",
+        np.array(attention_prior_window_left, dtype=np.int32),
+        trt.PluginFieldType.INT32)
+    attention_prior_window_right_field = trt.PluginField(
+        "attention_prior_window_right",
+        np.array(attention_prior_window_right, dtype=np.int32),
+        trt.PluginFieldType.INT32)
     max_distance = trt.PluginField("max_distance",
                                    np.array(max_distance, dtype=np.int32),
                                    trt.PluginFieldType.INT32)
@@ -5838,8 +5879,11 @@ def gpt_attention(
         block_sparse_block_size, block_sparse_homo_head_pattern,
         block_sparse_num_local_blocks, block_sparse_vertical_stride,
         paged_kv_cache, tokens_per_block, pf_type, max_context_length,
-        qkv_bias_enabled, do_cross_attention_field, max_distance,
-        pos_shift_enabled, dense_context_fmha, use_paged_context_fmha_field,
+        qkv_bias_enabled, do_cross_attention_field,
+        compute_attention_prior_field, apply_attention_prior_field,
+        attention_prior_lookahead_field, attention_prior_window_left_field,
+        attention_prior_window_right_field, max_distance, pos_shift_enabled,
+        dense_context_fmha, use_paged_context_fmha_field,
         use_fp8_context_fmha_field, has_full_attention_mask_field, use_cache_pf,
         is_spec_decoding_enabled, spec_decoding_is_generation_length_variable,
         spec_decoding_max_generation_length, is_mla_enabled, q_lora_rank,
@@ -5913,6 +5957,9 @@ def gpt_attention(
     if do_cross_attention:
         plug_inputs += [cross_kv, cross_kv_length, encoder_input_lengths]
 
+        if apply_attention_prior:
+            plug_inputs += [attention_prior_focus]
+
     if default_net().plugin_config.remove_input_padding:
         plug_inputs += [host_context_lengths]
 
@@ -5973,17 +6020,28 @@ def gpt_attention(
         expected_outputs += 1
 
     present_key_value = None
+    present_key_idx = -1
     if use_cache and not paged_kv_cache_flag:
         present_key_value = _create_tensor(layer.get_output(expected_outputs),
                                            layer)
         assert present_key_value is not None
+        present_key_idx = expected_outputs
         expected_outputs += 1
+
+    attention_prior_scores_out = None
+    if compute_attention_prior:
+        attention_prior_scores_out = _create_tensor(
+            layer.get_output(expected_outputs), layer)
+        assert attention_prior_scores_out is not None
 
     assert layer.num_outputs == expected_outputs, \
         f"Plugin outputs number mismatch with expected, got {layer.num_outputs}, expected {expected_outputs}"
 
     if kv_cache_quant_mode.has_int8_kv_cache(
     ) and not default_net().strongly_typed:
+        if present_key_idx >= 0:
+            # present key value
+            layer.get_output(present_key_idx).set_dynamic_range(-127, 127)
         if not paged_kv_cache_flag:
             # past key value
             layer.get_input(8).set_dynamic_range(-127, 127)
@@ -5995,10 +6053,14 @@ def gpt_attention(
             layer.get_output(expected_outputs - 1).set_dynamic_range(-127, 127)
 
     assert output is not None
+    outputs = [output]
     if fuse_fp4_quant:
         assert output_sf is not None
-        return (output, output_sf), present_key_value
-    return output, present_key_value
+        outputs.append(output_sf)
+    outputs.append(present_key_value)
+    if compute_attention_prior:
+        outputs.append(attention_prior_scores_out)
+    return outputs
 
 
 def assertion(condition: Tensor, message: str = '') -> None:

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -6033,6 +6033,7 @@ def gpt_attention(
         attention_prior_scores_out = _create_tensor(
             layer.get_output(expected_outputs), layer)
         assert attention_prior_scores_out is not None
+        expected_outputs += 1
 
     assert layer.num_outputs == expected_outputs, \
         f"Plugin outputs number mismatch with expected, got {layer.num_outputs}, expected {expected_outputs}"

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -30,7 +30,8 @@ from ..functional import (
     allgather, arange, bert_attention, cast, clip, concat, constant, embedding,
     expand, expand_dims, expand_mask, generate_alibi_biases, identity,
     generate_alibi_slopes, generate_logn_scaling, gpt_attention, matmul,
-    minimum, repeat_interleave, shape, slice, softmax, split, unsqueeze, where)
+    maximum, minimum, repeat_interleave, shape, slice, softmax, split,
+    unsqueeze, where)
 # isort: on
 from ..mapping import Mapping
 from ..module import Module, ModuleList
@@ -386,6 +387,11 @@ class Attention(Module):
                  quant_mode: QuantMode = QuantMode(0),
                  q_scaling=1.0,
                  cross_attention=False,
+                 compute_attention_prior=False,
+                 apply_attention_prior=False,
+                 attention_prior_lookahead=5,
+                 attention_prior_window_left=1,
+                 attention_prior_window_right=5,
                  relative_attention=False,
                  max_distance=0,
                  num_buckets=0,
@@ -408,6 +414,11 @@ class Attention(Module):
 
         self.local_layer_idx = local_layer_idx
         self.cross_attention = cross_attention
+        self.compute_attention_prior = compute_attention_prior
+        self.apply_attention_prior = apply_attention_prior
+        self.attention_prior_lookahead = attention_prior_lookahead
+        self.attention_prior_window_left = attention_prior_window_left
+        self.attention_prior_window_right = attention_prior_window_right
         self.attention_mask_type = attention_mask_type
         self.attention_head_size = hidden_size // num_attention_heads if attention_head_size is None else attention_head_size
         assert num_attention_heads % tp_size == 0, \
@@ -792,6 +803,7 @@ class Attention(Module):
         kv_cache_params=None,
         attention_params=None,
         encoder_output: Optional[Tensor] = None,
+        attention_prior_focus: Optional[Tensor] = None,
         position_embedding=None,
         norm_before_bmm1=False,
         lora_layer_params=None,
@@ -1118,7 +1130,7 @@ class Attention(Module):
                 assert long_rope_rotary_inv_freq is not None
                 assert long_rope_rotary_cos_sin is not None
 
-            context, past_key_value = gpt_attention(
+            attn_outputs = gpt_attention(
                 qkv=qkv,
                 past_key_value=past_key_value,
                 attention_mask=attention_mask,
@@ -1184,9 +1196,15 @@ class Attention(Module):
                 host_kv_cache_pool_mapping if not self.cross_attention else
                 kv_cache_params.host_cross_kv_cache_pool_mapping,
                 do_cross_attention=self.cross_attention,
+                compute_attention_prior=self.compute_attention_prior,
+                apply_attention_prior=self.apply_attention_prior,
+                attention_prior_lookahead=self.attention_prior_lookahead,
+                attention_prior_window_left=self.attention_prior_window_left,
+                attention_prior_window_right=self.attention_prior_window_right,
                 cross_kv=cross_kv,
                 cross_kv_length=attention_params.encoder_max_input_length,
                 encoder_input_lengths=attention_params.encoder_input_lengths,
+                attention_prior_focus=attention_prior_focus,
                 logn_scaling=logn_scaling,
                 relative_attention_bias=self.rel_attn_table.value
                 if self.relative_attention else None,
@@ -1216,6 +1234,13 @@ class Attention(Module):
                 cp_size=self.cp_size,
                 cp_rank=self.cp_rank,
                 cp_group=self.cp_group)
+
+            if self.compute_attention_prior:
+                attention_prior_scores = attn_outputs.pop()
+            past_key_value = attn_outputs.pop()
+            # unpack if context is a single tensor
+            context = attn_outputs[0] if len(
+                attn_outputs) == 1 else attn_outputs
 
         else:
             # plain TensorRT mode
@@ -1582,10 +1607,12 @@ class Attention(Module):
         ).plugin_config.use_fp8_context_fmha:
             context = dense_conditional.add_output(skip_case, context)
 
+        outputs = [context]
         if use_cache:
-            return (context, past_key_value)
-        else:
-            return context
+            outputs.append(past_key_value)
+        if self.compute_attention_prior:
+            outputs.append(attention_prior_scores)
+        return outputs
 
     def set_rel_attn_table(self, max_seq_len, precomputed_relative_attention):
         self.rel_attn_table = Parameter(shape=(self.num_attention_heads,

--- a/tensorrt_llm/layers/embedding.py
+++ b/tensorrt_llm/layers/embedding.py
@@ -111,6 +111,8 @@ class Embedding(Module):
     def postprocess(self, tllm_key, weights, **kwargs):
         if weights is None:
             return {}
+        if isinstance(weights, Sequence):
+            weights = torch.vstack(weights)
         weights = weights.to(str_dtype_to_torch(self.dtype))
         return {tllm_key: weights}
 

--- a/tensorrt_llm/llmapi/mgmn_worker_node.py
+++ b/tensorrt_llm/llmapi/mgmn_worker_node.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 import logging
 
+import torch
 from mpi4py.futures import MPICommExecutor
 from mpi4py.MPI import COMM_WORLD
 
+from tensorrt_llm._utils import global_mpi_rank, local_mpi_size
+
+device_id = global_mpi_rank() % local_mpi_size()
+torch.cuda.set_device(device_id)
 # For multi-node MPI, the worker nodes should launch MPICommExecutor to accept tasks sent from rank0
 with MPICommExecutor(COMM_WORLD) as executor:
     if executor is not None:

--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -62,6 +62,7 @@ from .qwen.model import QWenForCausalLM
 from .recurrentgemma.model import RecurrentGemmaForCausalLM
 from .redrafter.model import ReDrafterForLLaMALM, ReDrafterForQWenLM
 from .stdit.model import STDiT3Model
+from .t5tts.model import T5TTSDecoderModel, T5TTSEncoderModel
 
 __all__ = [
     'BertModel',
@@ -134,6 +135,8 @@ __all__ = [
     'SpeculativeDecodingMode',
     'CohereForCausalLM',
     'MLLaMAForCausalLM',
+    'T5TTSEncoderModel',
+    'T5TTSDecoderModel',
 ]
 
 MODEL_MAP = {
@@ -220,4 +223,6 @@ MODEL_MAP = {
     'RobertaModel': RobertaModel,
     'RobertaForQuestionAnswering': RobertaForQuestionAnswering,
     'RobertaForSequenceClassification': RobertaForSequenceClassification,
+    'T5TTSEncoderModel': T5TTSEncoderModel,
+    'T5TTSDecoderModel': T5TTSDecoderModel,
 }

--- a/tensorrt_llm/models/generation_mixin.py
+++ b/tensorrt_llm/models/generation_mixin.py
@@ -80,18 +80,18 @@ class GenerationMixin:
         return num_tokens_ranges
 
     @staticmethod
-    def get_profiles_ranges(
-            *,
-            max_batch_size,
-            max_beam_width,
-            max_input_len,
-            max_num_tokens,
-            max_draft_len,
-            opt_batch_size,
-            opt_num_tokens,
-            enable_ctx_gen_opt_profiles,
-            multiple_profiles,
-            kv_cache_type: KVCacheType = KVCacheType.CONTINUOUS):
+    def get_profiles_ranges(*,
+                            max_batch_size,
+                            max_beam_width,
+                            max_input_len,
+                            max_num_tokens,
+                            max_draft_len,
+                            opt_batch_size,
+                            opt_num_tokens,
+                            enable_ctx_gen_opt_profiles,
+                            multiple_profiles,
+                            kv_cache_type: KVCacheType = KVCacheType.CONTINUOUS,
+                            num_vocabs: int = 1):
         default_range = GenerationMixin.default_range
         if opt_batch_size:
             bb_range_cxt = [1, opt_batch_size, max_batch_size]
@@ -168,6 +168,8 @@ class GenerationMixin:
                     [math.ceil(x[0] / (max_draft_len + 1)), x[1], x[2]],
                     num_tokens_range))
 
+        num_tokens_range = [[rr * num_vocabs for rr in r]
+                            for r in num_tokens_range]
         ranges = {
             'bb_range': bb_range,
             'bbd_range': bbd_range,
@@ -542,6 +544,7 @@ class GenerationMixin:
         opt_batch_size=None,
         pp_reduce_scatter: bool = False,
         mrope_rotary_cos_sin_size: int = None,
+        num_vocabs: int = 1,
     ):
 
         enable_ctx_gen_opt_profiles = GenerationMixin.has_ctx_gen_opt_profiles(
@@ -560,7 +563,8 @@ class GenerationMixin:
             opt_num_tokens=opt_num_tokens,
             enable_ctx_gen_opt_profiles=enable_ctx_gen_opt_profiles,
             multiple_profiles=multiple_profiles,
-            kv_cache_type=kv_cache_type)
+            kv_cache_type=kv_cache_type,
+            num_vocabs=num_vocabs)
         bb_range = ranges['bb_range']
         bbd_range = ranges['bbd_range']
         inlen_range = ranges['inlen_range']

--- a/tensorrt_llm/models/llama/config.py
+++ b/tensorrt_llm/models/llama/config.py
@@ -16,7 +16,7 @@ import json
 import math
 import sys
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from ...layers import MoeConfig
 from ...mapping import Mapping
@@ -40,6 +40,7 @@ class LLaMAConfig(PretrainedConfig):
                  attention_multiplier: float = 1.0,
                  residual_multiplier: float = 1.0,
                  output_multiplier_scale: float = 1.0,
+                 vocab_sizes: Optional[List[int]] = None,
                  **kwargs):
         self.mlp_bias = mlp_bias
         self.attn_bias = attn_bias
@@ -68,6 +69,7 @@ class LLaMAConfig(PretrainedConfig):
         self.attention_multiplier = attention_multiplier
         self.residual_multiplier = residual_multiplier
         self.output_multiplier_scale = output_multiplier_scale
+        self.vocab_sizes = vocab_sizes
         self.has_partial_lora_mask = False
 
         super().__init__(**kwargs)
@@ -87,6 +89,7 @@ class LLaMAConfig(PretrainedConfig):
             'use_input_layernorm_in_first_layer'] = self.use_input_layernorm_in_first_layer
         output['use_last_layernorm'] = self.use_last_layernorm
         output['layer_idx_offset'] = self.layer_idx_offset
+        output['vocab_sizes'] = self.vocab_sizes
         output['moe'] = self.moe.to_dict()
         return output
 
@@ -189,6 +192,7 @@ class LLaMAConfig(PretrainedConfig):
 
         dtype = infer_dtype(dtype, getattr(hf_config, 'torch_dtype', None))
         tie_word_embeddings = getattr(hf_config, 'tie_word_embeddings', False)
+        vocab_sizes = getattr(hf_config, 'vocab_sizes', None)
 
         return cls(
             architecture=hf_config.architectures[0],
@@ -219,6 +223,7 @@ class LLaMAConfig(PretrainedConfig):
             attention_multiplier=attention_multiplier,
             residual_multiplier=residual_multiplier,
             output_multiplier_scale=output_multiplier_scale,
+            vocab_sizes=vocab_sizes,
             **kwargs)
 
     @classmethod

--- a/tensorrt_llm/models/llama/convert.py
+++ b/tensorrt_llm/models/llama/convert.py
@@ -1616,9 +1616,10 @@ def load_weights_from_hf_safetensors(model_dir: str, config: LLaMAConfig):
                 weights[target.replace("weight", "bias")] = bias
 
     if mapping.is_first_pp_rank():
-        weights['transformer.vocab_embedding.weight'] = load(
-            param_name_map["vocab_embedding"], config.embedding_sharding_dim
-            if config.use_parallel_embedding else -1)  # vocab_embedding
+        v = load(param_name_map["vocab_embedding"],
+                 config.embedding_sharding_dim
+                 if config.use_parallel_embedding else -1)  # vocab_embedding
+        weights['transformer.vocab_embedding.weight'] = v
 
     if mapping.is_last_pp_rank():
         v = load(param_name_map["lm_head"], -1, 1) if pad_vocab else load(

--- a/tensorrt_llm/models/llama/model.py
+++ b/tensorrt_llm/models/llama/model.py
@@ -21,7 +21,7 @@ from ..._common import default_net
 from ..._utils import pad_vocab_size
 from ...functional import (AllReduceFusionOp, AllReduceParams, Tensor,
                            allgather, concat, constant, div, non_gated_version,
-                           recv, send, unsqueeze)
+                           recv, select, send, shape, unsqueeze, view)
 from ...layers import (MOE, Attention, AttentionMaskType, ColumnLinear,
                        Embedding, FusedGatedMLP, GatedMLP,
                        PositionEmbeddingType, RmsNorm)
@@ -313,6 +313,7 @@ class LLaMAModel(Module):
         self.vocab_size = config.vocab_size
         self.has_partial_lora_mask = config.has_partial_lora_mask
         self.hidden_size = config.hidden_size
+        self.num_vocabs = len(config.vocab_sizes) if config.vocab_sizes else 1
         if self.mapping.is_first_pp_rank():
             self.vocab_embedding = Embedding(config.vocab_size,
                                              config.hidden_size,
@@ -357,9 +358,22 @@ class LLaMAModel(Module):
         ] if prompt_embedding_table is not None else []
 
         if self.mapping.is_first_pp_rank():
-            hidden_states = self.vocab_embedding(input_ids, *ptuning_args)
+            hidden_states = self.vocab_embedding(
+                input_ids, *ptuning_args)  # seqlen x num_vocabs x hidden_size
+            hidden_states = view(hidden_states,
+                                 concat([
+                                     shape(hidden_states, 0) / self.num_vocabs,
+                                     self.num_vocabs, -1
+                                 ]))  # shape [totalSeqLen, nVocab, embDim]
+            # TODO: for debug pick the very first sampled token, ignore rest
+            # in the future:
+            # hidden_states = sum(hidden_states, 1, keepdim=False)
+            # shape [totalSeqLen, embDim]
+            # hidden_states[:, 0, :]
+            hidden_states = select(hidden_states, 1, 0)
             hidden_states *= self.embedding_multiplier
         else:
+            # TODO: not supported for multi-vocab yet.
             hidden_states = recv(hidden_states, self.mapping.prev_pp_rank())
             if default_net().plugin_config.pp_reduce_scatter:
                 hidden_states = allgather(hidden_states,

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -899,7 +899,10 @@ class PretrainedModel(Module,
             streamingllm=streamingllm,
             opt_batch_size=opt_batch_size,
             pp_reduce_scatter=pp_reduce_scatter,
-            mrope_rotary_cos_sin_size=mrope_rotary_cos_sin_size)
+            mrope_rotary_cos_sin_size=mrope_rotary_cos_sin_size,
+            num_vocabs=len(self.config.vocab_sizes) if
+            (hasattr(self.config, 'vocab_sizes')
+             and self.config.vocab_sizes) else 1)
 
         result = {
             'input_ids':

--- a/tensorrt_llm/models/t5tts/__init__.py
+++ b/tensorrt_llm/models/t5tts/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -460,7 +460,7 @@ class ModelRunnerCpp(ModelRunnerMixin):
             len(x) for x in encoder_input_ids
         ] if encoder_input_ids else [len(x) for x in batch_input_ids]
         max_length = max(input_lengths)
-        if max_length > self.max_input_len:
+        if max_length > self.max_input_len * len(self.model_config.vocab_sizes):
             raise RuntimeError(
                 f"Maximum input length ({max_length}) exceeds the engine or specified limit ({self.max_input_len})"
             )
@@ -471,7 +471,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
                     f"Decoder prefix tokens ({decoder_max_length}) + maximum new tokens ({max_new_tokens}) exceeds the engine or specified limit ({self.max_seq_len})"
                 )
         else:
-            if max_length + max_new_tokens > self.max_seq_len:
+            if max_length + max_new_tokens > self.max_seq_len * len(
+                    self.model_config.vocab_sizes):
                 raise RuntimeError(
                     f"Maximum input length ({max_length}) + maximum new tokens ({max_new_tokens}) exceeds the engine or specified limit ({self.max_seq_len})"
                 )
@@ -537,6 +538,7 @@ class ModelRunnerCpp(ModelRunnerMixin):
             encoder_input_features: List[
                 torch.Tensor] = None,  # TODO: add to doc string
             encoder_output_lengths: List[int] = None,
+            decoder_context_features: List[torch.Tensor] = None,
             cross_attention_masks: List[
                 torch.Tensor] = None,  # TODO: add to doc string
             mrope_params: Optional[MropeParams] = None,
@@ -579,6 +581,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 A list of encoder input feature tensors for multimodal encoder-decoder models (optional). Each tensor is of shape (sequence_length, feature_dim).
             encoder_output_lengths: (List[int]):
                 A list of encoder output lengths (optional) if encoder output has different length from encoder input (due to convolution down-sampling, etc.)
+            decoder_context_features (List[torch.Tensor]):
+                A list of decoder context feature tensors for multimodal decoder-only models (optional). Each tensor is of shape (sequence_length, feature_dim).
             sampling_config (SamplingConfig):
                 The sampling configuration to be used as base parametrization for the generation call.
                 The passed **kwargs matching the sampling_config's attributes will override them.
@@ -651,6 +655,7 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 "num_return_sequences",
                 "min_p",
                 "beam_width_array",
+                "cfg_scale",
             ]
             rename_params = {"num_beams": "beam_width", "random_seed": "seed"}
             sampling_params = {
@@ -758,6 +763,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 if encoder_output_lengths is not None else None,
                 encoder_input_features=encoder_input_features[i].contiguous()
                 if encoder_input_features is not None else None,
+                decoder_context_features=decoder_context_features[i].contiguous(
+                ) if decoder_context_features is not None else None,
                 position_ids=position_ids[i].tolist()
                 if position_ids is not None else None,
                 cross_attention_mask=cross_attention_masks[i].contiguous() if
@@ -782,6 +789,9 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 external_draft_tokens_config=external_draft_tokens_config,
                 skip_cross_attn_blocks=skip_cross_attn_blocks,
                 language_adapter_uid=language_adapter_uid,
+                num_vocabs=len(self.model_config.vocab_sizes) if
+                (hasattr(self.model_config, 'vocab_sizes')
+                 and self.model_config.vocab_sizes) else 1,
             ) for i,
             (input_ids, stop_words, bad_words, prompt_tuning_config,
              mrope_config, lora_config, logits_post_processor_name,
@@ -1083,7 +1093,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
 
             input_lengths = torch.tensor([x.size(0) for x in batch_input_ids],
                                          dtype=torch.int32,
-                                         device=cuda_device)
+                                         device=cuda_device) // len(
+                                             self.model_config.vocab_sizes)
 
             if output_sequence_lengths:
                 outputs['sequence_lengths'] = torch.tensor(sequence_lengths,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
